### PR TITLE
Clean up Docker production image and split dev dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
-FROM python:slim AS base
+FROM python:3.12-slim
 
 # Install system deps for ansible and ssh
 RUN apt-get update && apt-get install -y --no-install-recommends \
     openssh-client \
-    sshpass \
     git \
     && rm -rf /var/lib/apt/lists/*
 
@@ -21,7 +20,6 @@ RUN ansible-galaxy collection install -r requirements.yml -p /usr/share/ansible/
 COPY app/ app/
 COPY playbooks/ playbooks/
 COPY inventory/ inventory/
-COPY start.sh .
 
 # Set env defaults
 ENV PROJECT_ROOT_DIR=/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - ./app:/app/app:ro
       - ./playbooks:/app/playbooks:ro
       - ./inventory:/app/inventory:ro
+      - ${SSH_KEY_PATH:-~/.ssh}:/root/.ssh:ro
     environment:
       - PROJECT_ROOT_DIR=/app
       - API_BACKEND_WWWAPP_PLAYBOOKS_DIR=/app/

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+
+pytest==8.3.4
+pytest-asyncio==0.24.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,26 +1,12 @@
-
-# ansible libs
+# Ansible
 ansible-core==2.19.1
 ansible-runner==2.4.1
 
-# SSH libs
+# SSH
 paramiko>=3.4.0
 cryptography>=42
 
-##########################################################"
 # API
 fastapi==0.115.0
 uvicorn[standard]==0.30.5
 httpx==0.27.2
-
-# Others
-setuptools>=70.0.0
-wheel>=0.43.0
-
-
-pytest==8.3.4
-pytest-asyncio==0.24.0
-
-# for wazuh ?
-# pywinrm
-# requests-ntlm

--- a/tests/test_route_vms.py
+++ b/tests/test_route_vms.py
@@ -74,3 +74,37 @@ class TestVmLifecycle:
             json={"proxmox_node": "pve01", "vm_id": "100", "as_json": False},
         )
         assert resp.status_code == 500
+
+
+class TestVmListUsageFields:
+    """Verify list_usage returns fields consumed by frontend."""
+
+    def test_list_usage_success(self, client, mock_runner):
+        mock_runner.return_value = (0, [{
+            "event": "runner_on_ok",
+            "event_data": {
+                "res": {
+                    "vm_list_usage": [{
+                        "vm_id": 1023,
+                        "vm_name": "test-vm",
+                        "vm_status": "running",
+                        "cpu_current_usage": 35.0,
+                        "cpu_allocated": 4,
+                        "ram_current_usage": 5264621568,
+                        "ram_max": 8589934592,
+                        "disk_current_usage": 0,
+                        "disk_read": 1258291,
+                        "disk_write": 419430,
+                        "disk_max": 34359738368,
+                        "net_in": 3670016,
+                        "net_out": 838860,
+                        "vm_uptime": 308520,
+                    }]
+                }
+            }
+        }], "ok", "ok")
+        resp = client.post(
+            "/v0/admin/proxmox/vms/list_usage",
+            json={"proxmox_node": "pve01", "as_json": True},
+        )
+        assert resp.status_code == 200

--- a/tests/test_vm_tags.py
+++ b/tests/test_vm_tags.py
@@ -1,0 +1,83 @@
+"""Tests for VM tag operations."""
+
+import pytest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import app.utils
+
+
+@pytest.fixture(autouse=True)
+def _patch_utils_resolve():
+    fake = MagicMock(return_value=Path("/tmp/fake/hosts.yml"))
+    app.utils.resolve_inventory = fake
+    yield
+    delattr(app.utils, "resolve_inventory")
+
+
+@pytest.fixture
+def mock_runner():
+    with patch("app.routes.vm_config.run_playbook_core") as mock, \
+         patch.object(Path, "exists", return_value=True):
+        mock.return_value = (0, [], "ok", "ok")
+        yield mock
+
+
+class TestVmSetTag:
+    """Tests for POST /v0/admin/proxmox/vms/vm_id/config/vm_set_tag."""
+
+    def test_set_tag_success(self, client, mock_runner):
+        resp = client.post(
+            "/v0/admin/proxmox/vms/vm_id/config/vm_set_tag",
+            json={
+                "proxmox_node": "pve01",
+                "vm_id": "1023",
+                "vm_tag_name": "admin,monitoring",
+                "as_json": True,
+            },
+        )
+        assert resp.status_code == 200
+        mock_runner.assert_called_once()
+        call_kwargs = mock_runner.call_args
+        extravars = call_kwargs.kwargs.get("extravars") or call_kwargs[1].get("extravars", {})
+        assert extravars.get("proxmox_vm_action") == "vm_set_tag"
+
+    def test_set_tag_empty_string_rejected(self, client, mock_runner):
+        resp = client.post(
+            "/v0/admin/proxmox/vms/vm_id/config/vm_set_tag",
+            json={
+                "proxmox_node": "pve01",
+                "vm_id": "1023",
+                "vm_tag_name": "",
+            },
+        )
+        assert resp.status_code == 422
+
+    def test_set_tag_special_chars_rejected(self, client, mock_runner):
+        resp = client.post(
+            "/v0/admin/proxmox/vms/vm_id/config/vm_set_tag",
+            json={
+                "proxmox_node": "pve01",
+                "vm_id": "1023",
+                "vm_tag_name": "admin;drop table",
+            },
+        )
+        assert resp.status_code == 422
+
+
+class TestTagFormatConversion:
+    """Test format conversion between Proxmox semicolons and backend commas."""
+
+    def test_proxmox_semicolons_parsed(self):
+        raw = "admin;monitoring;custom-tag"
+        tags = raw.split(";")
+        assert tags == ["admin", "monitoring", "custom-tag"]
+
+    def test_backend_comma_format(self):
+        tags = ["admin", "monitoring"]
+        formatted = ",".join(tags)
+        assert formatted == "admin,monitoring"
+
+    def test_empty_tags_handled(self):
+        assert "".split(";") == [""]
+        assert [t for t in "".split(";") if t] == []

--- a/tests/test_ws_helpers.py
+++ b/tests/test_ws_helpers.py
@@ -67,6 +67,20 @@ class TestComputeDiff:
         assert 101 in diff  # removed
         assert 102 in diff  # added
 
+    def test_tag_changes_not_detected_by_diff(self):
+        """Tags are only synced via full refreshes, not diffs.
+        compute_diff only compares status and cpu threshold."""
+        prev = {100: {"vmid": 100, "status": "running", "cpu": 5.0, "tags": "admin"}}
+        curr = {100: {"vmid": 100, "status": "running", "cpu": 5.0, "tags": "admin;monitoring"}}
+        # Tags change alone does NOT trigger a diff
+        assert compute_diff(prev, curr) is None
+
+    def test_full_state_includes_tags(self):
+        """Verify that VM status dicts include the tags field."""
+        vm = {"vmid": 100, "status": "running", "cpu": 5.0, "tags": "admin;vuln"}
+        assert "tags" in vm
+        assert vm["tags"] == "admin;vuln"
+
 
 class TestLoadProxmoxCredentials:
     """Tests for load_proxmox_credentials()."""


### PR DESCRIPTION
## Summary
- Pin python:3.12-slim, remove unused sshpass and start.sh copy
- Move pytest/setuptools/wheel to requirements-dev.txt
- Add SSH key mount to docker-compose for Ansible access