### PR TITLE
feat(network): canonical template reconciliation + CIDR-aware inventory (network epic)

### DIFF
--- a/app/core/deploy_trigger.py
+++ b/app/core/deploy_trigger.py
@@ -173,6 +173,20 @@ async def start_attempt(session: AsyncSession, *, attempt: Attempt,
         else:
             proxmox_address = api_url.split(":", 1)[0]
 
+        # Proxmox API creds for the _universal playbook's node-network tasks
+        # (the proxmox_controller role reads proxmox_api_* as plain vars; the
+        # generated inventory carries no token). token_ref: "user!tokenid=secret".
+        extravars["proxmox_api_host"] = api_url.split("://", 1)[-1].rstrip("/")
+        extravars["proxmox_node"] = target_host.node_name
+        _tok = target_host.token_ref or ""
+        if "!" in _tok and "=" in _tok:
+            _userpart, _secret = _tok.split("=", 1)
+            _user, _tokid = _userpart.split("!", 1)
+            extravars["proxmox_api_user"] = _user
+            extravars["proxmox_api_token_id"] = _tokid
+            extravars["proxmox_api_token_secret"] = _secret
+            tainted.add(_secret)
+
         inventory_dir = ws / "inventory"
         inventory_dir.mkdir(parents=True, exist_ok=True)
         write_inventory(

--- a/app/core/deploy_trigger.py
+++ b/app/core/deploy_trigger.py
@@ -108,6 +108,9 @@ async def start_attempt(session: AsyncSession, *, attempt: Attempt,
         "r42_scope": attempt.scope,
         "r42_team_id": attempt.team_id,
         "r42_playbook_path": str(playbook_path),
+        # team_count is a per-team multiplier the playbook needs on every host
+        # (set_fact on localhost is not visible to the proxmox-cli plays).
+        "team_count": dep.team_count or 1,
     }
 
     # Build the tainted-string set for substring redaction. Always includes

--- a/app/core/inventory_writer.py
+++ b/app/core/inventory_writer.py
@@ -20,10 +20,15 @@ side effects — safe to call from ``start_attempt()`` (T8).
 """
 from __future__ import annotations
 
+import ipaddress
 from pathlib import Path
 from typing import Any
 
 import yaml
+
+# Reuse the canonical per-team template renderer so inventory CIDR resolution
+# never drifts from the playbook/compose expansion (see #84).
+from app.overlay.expand_replication import _render_template
 
 
 # Node kinds that become Ansible hosts (others are infra primitives)
@@ -94,6 +99,53 @@ def _ip_for_node(bridge_base: int, team_id: int | None, seq: int) -> str:
     return f"192.168.{octet}.{200 + seq}"
 
 
+def _resolve_network_cidr(
+    net_node: dict, team_id: int | None, bridge_base: int
+) -> str | None:
+    """Resolve a network node's CIDR, rendering a node-level ``cidr_template``
+    (canonical schema form) for the given team if needed."""
+    if net_node.get("cidr"):
+        return net_node["cidr"]
+    tpl = net_node.get("cidr_template")
+    if tpl:
+        return _render_template(tpl, team_id or 0, bridge_base)
+    return None
+
+
+def _host_ip_from_cidr(cidr: str, seq: int) -> str | None:
+    """Derive a host address inside ``cidr`` following the existing host-octet
+    convention (network address + 200 + seq). Returns None on a malformed CIDR."""
+    try:
+        net = ipaddress.ip_network(cidr, strict=False)
+    except ValueError:
+        return None
+    return str(net.network_address + (200 + seq))
+
+
+def _ansible_host_ip(
+    node: dict, team_id: int | None, seq: int, bridge_base: int,
+    networks_by_id: dict[str, dict],
+) -> str:
+    """Determine a host's ansible_host. Precedence: explicit NIC ip >
+    node_ref-bound network CIDR derivation > hardcoded 192.168.{bridge_base}
+    fallback (backward-compatible with topologies that omit networks[])."""
+    nics = node.get("networks") or []
+    primary = nics[0] if nics else None
+    if primary:
+        explicit = primary.get("ip")
+        if explicit:
+            return explicit
+        ref = primary.get("node_ref")
+        net = networks_by_id.get(ref) if ref else None
+        if net is not None:
+            cidr = _resolve_network_cidr(net, team_id, bridge_base)
+            if cidr:
+                derived = _host_ip_from_cidr(cidr, seq)
+                if derived:
+                    return derived
+    return _ip_for_node(bridge_base, team_id, seq)
+
+
 def write_inventory(
     *,
     topology: dict[str, Any],
@@ -124,6 +176,13 @@ def write_inventory(
 
     # Filter nodes: only vm/lxc/docker become Ansible hosts
     host_nodes = [n for n in topology.get("nodes", []) if n.get("kind") in _HOST_KINDS]
+
+    # Network nodes, keyed by id, for NIC node_ref -> CIDR resolution.
+    networks_by_id = {
+        n.get("id"): n
+        for n in topology.get("nodes", [])
+        if n.get("kind") == "network" and n.get("id")
+    }
 
     children: dict[str, dict[str, Any]] = {
         "r42_admin": {"hosts": {}},
@@ -157,7 +216,7 @@ def write_inventory(
 
         host = _hostname(prefix, team_id, node_id)
         user = ssh_user_for_role.get(role, _DEFAULT_SSH_USER.get(role, "alice"))
-        ip = _ip_for_node(bridge_base, team_id, seq)
+        ip = _ansible_host_ip(node, team_id, seq, bridge_base, networks_by_id)
 
         children[group]["hosts"][host] = {
             "ansible_host": ip,

--- a/app/core/inventory_writer.py
+++ b/app/core/inventory_writer.py
@@ -122,6 +122,70 @@ def _host_ip_from_cidr(cidr: str, seq: int) -> str | None:
     return str(net.network_address + (200 + seq))
 
 
+def _resolve_network(
+    net_node: dict, team_id: int | None, bridge_base: int
+) -> dict[str, str | None]:
+    """Resolve a network node's ``{bridge, cidr, gateway}`` for a team,
+    rendering node-level templates via the canonical renderer."""
+    tid = team_id or 0
+    bridge = net_node.get("bridge")
+    if not bridge and net_node.get("bridge_template"):
+        bridge = _render_template(net_node["bridge_template"], tid, bridge_base)
+    gateway = net_node.get("gateway")
+    if not gateway and net_node.get("gateway_template"):
+        gateway = _render_template(net_node["gateway_template"], tid, bridge_base)
+    return {
+        "bridge": bridge,
+        "cidr": _resolve_network_cidr(net_node, team_id, bridge_base),
+        "gateway": gateway,
+    }
+
+
+def _host_ci_net(
+    node: dict, team_id: int | None, bridge_base: int,
+    networks_by_id: dict[str, dict],
+) -> tuple[int, str, str]:
+    """Per-host cloud-init network triple (netmask, gateway, bridge). Derived
+    from the bound network, else the legacy 192.168.{bridge_base+team} scheme."""
+    octet = bridge_base + (team_id or 0)
+    netmask, gateway, bridge = 24, f"192.168.{octet}.1", f"vmbr{octet}"
+    nics = node.get("networks") or []
+    primary = nics[0] if nics else None
+    ref = primary.get("node_ref") if primary else None
+    if ref and ref in networks_by_id:
+        r = _resolve_network(networks_by_id[ref], team_id, bridge_base)
+        if r["cidr"] and "/" in r["cidr"]:
+            try:
+                netmask = int(r["cidr"].split("/")[1])
+            except ValueError:
+                pass
+        if r["gateway"]:
+            gateway = r["gateway"]
+        if r["bridge"]:
+            bridge = r["bridge"]
+    return netmask, gateway, bridge
+
+
+def _build_network_map(
+    topology: dict, team_count: int, bridge_base: int
+) -> dict[str, dict[str, dict]]:
+    """Per network id, the resolved {bridge, cidr, gateway} keyed by team id
+    (or 'shared') — the single source the playbook reads to create bridges."""
+    out: dict[str, dict[str, dict]] = {}
+    for net in topology.get("nodes", []):
+        if net.get("kind") != "network" or not net.get("id"):
+            continue
+        scope = (net.get("replication") or {}).get("scope", "shared")
+        entry: dict[str, dict] = {}
+        if scope == "per_team":
+            for tid in range(1, team_count + 1):
+                entry[str(tid)] = _resolve_network(net, tid, bridge_base)
+        else:
+            entry["shared"] = _resolve_network(net, None, bridge_base)
+        out[net["id"]] = entry
+    return out
+
+
 def _ansible_host_ip(
     node: dict, team_id: int | None, seq: int, bridge_base: int,
     networks_by_id: dict[str, dict],
@@ -217,6 +281,9 @@ def write_inventory(
         host = _hostname(prefix, team_id, node_id)
         user = ssh_user_for_role.get(role, _DEFAULT_SSH_USER.get(role, "alice"))
         ip = _ansible_host_ip(node, team_id, seq, bridge_base, networks_by_id)
+        ci_netmask, ci_gateway, net_bridge = _host_ci_net(
+            node, team_id, bridge_base, networks_by_id
+        )
 
         children[group]["hosts"][host] = {
             "ansible_host": ip,
@@ -229,6 +296,10 @@ def write_inventory(
             "r42_team_id": team_id,
             "r42_node_name": node_id,
             "r42_template_vmid": node.get("template_vmid"),
+            # Cloud-init network triple — single source for the playbook (#73).
+            "r42_ci_netmask": ci_netmask,
+            "r42_ci_gateway": ci_gateway,
+            "r42_net_bridge": net_bridge,
         }
 
         # If this node has a wazuh-agent attachment, also list under
@@ -241,7 +312,8 @@ def write_inventory(
             if "wazuh" in ref.lower() and "agent" in ref.lower():
                 children["r42_admin_wazuh_clients"]["hosts"][host] = {}
 
-    inv = {"all": {"children": children}}
+    network_map = _build_network_map(topology, team_count, bridge_base)
+    inv = {"all": {"vars": {"r42_network_map": network_map}, "children": children}}
     dest.parent.mkdir(parents=True, exist_ok=True)
     dest.write_text(yaml.safe_dump(inv, sort_keys=False))
     return dest

--- a/app/routes/v1/proxmox/vms.py
+++ b/app/routes/v1/proxmox/vms.py
@@ -23,7 +23,12 @@ from app.routes.v1.proxmox._helpers import (
     _unreachable,
 )
 from app.schemas.v1.common import Page
-from app.schemas.v1.proxmox import TaskStatus, VmActionResult, VmSummary
+from app.schemas.v1.proxmox import (
+    TaskStatus,
+    VmActionResult,
+    VmConfigResult,
+    VmSummary,
+)
 
 router = APIRouter()
 log = get_logger(__name__)
@@ -73,6 +78,45 @@ async def list_host_vms(host_id: str, session: AsyncSession = Depends(_session))
         raise _unreachable(row, e) from e
     return Page[VmSummary](
         items=items, total=len(items), offset=0, limit=len(items)
+    )
+
+
+@router.get(
+    "/hosts/{host_id}/vms/{vmid}/config", response_model=VmConfigResult
+)
+async def vm_config(
+    host_id: str,
+    vmid: int,
+    vmtype: Literal["qemu", "lxc"] = "qemu",
+    session: AsyncSession = Depends(_session),
+):
+    """Return the raw PVE guest config (net0/net1/ipconfig*, etc.). The UI import
+    flow parses net* to rebuild per-NIC bridge/network edges (#79); the v1 VM
+    list deliberately omits per-NIC detail."""
+    row = await _get_host(host_id, session)
+    base = row.api_url.rstrip("/")
+    url = f"{base}/api2/json/nodes/{row.node_name}/{vmtype}/{vmid}/config"
+    try:
+        async with httpx.AsyncClient(verify=False, timeout=15) as cli:
+            r = await cli.get(url, headers=_auth_headers(row))
+    except httpx.RequestError as e:
+        raise _unreachable(row, e) from e
+    if r.status_code in (401, 403):
+        raise AuthFailedError(details=[{
+            "field": "token_ref",
+            "reason": f"Proxmox API rejected credentials ({r.status_code})",
+        }])
+    if r.status_code != 200:
+        raise Range42Error(
+            error="upstream_error",
+            code="PROXMOX_ERROR",
+            status=502,
+            message=f"Proxmox returned {r.status_code} for vm config",
+            details=[{"field": "vmid", "reason": (r.text or "")[:300]}],
+        )
+    return VmConfigResult(
+        vmid=vmid, node=row.node_name, type=vmtype,
+        config=r.json().get("data", {}) or {},
     )
 
 

--- a/app/schemas/v1/proxmox.py
+++ b/app/schemas/v1/proxmox.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import re
 from datetime import datetime
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, HttpUrl, field_validator
 
@@ -127,3 +127,12 @@ class SnapshotCreateIn(BaseModel):
     snapname: str
     description: str | None = None
     vmstate: bool | None = None
+
+
+class VmConfigResult(BaseModel):
+    """Raw PVE guest config (net0/net1/ipconfig*, cores, memory, ...). The UI
+    import flow parses net* to reconstruct per-NIC bridge/network edges (#79)."""
+    vmid: int
+    node: str
+    type: Literal["qemu", "lxc"] = "qemu"
+    config: dict[str, Any]

--- a/openapi.json
+++ b/openapi.json
@@ -3603,6 +3603,72 @@
         }
       }
     },
+    "/v1/proxmox/hosts/{host_id}/vms/{vmid}/config": {
+      "get": {
+        "tags": [
+          "v1 proxmox"
+        ],
+        "summary": "Vm Config",
+        "description": "Return the raw PVE guest config (net0/net1/ipconfig*, etc.). The UI import\nflow parses net* to rebuild per-NIC bridge/network edges (#79); the v1 VM\nlist deliberately omits per-NIC detail.",
+        "operationId": "vm_config_v1_proxmox_hosts__host_id__vms__vmid__config_get",
+        "parameters": [
+          {
+            "name": "host_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Host Id"
+            }
+          },
+          {
+            "name": "vmid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Vmid"
+            }
+          },
+          {
+            "name": "vmtype",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "enum": [
+                "qemu",
+                "lxc"
+              ],
+              "type": "string",
+              "default": "qemu",
+              "title": "Vmtype"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VmConfigResult"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/proxmox/hosts/{host_id}/vms/{vmid}/status/{action}": {
       "post": {
         "tags": [
@@ -9821,6 +9887,40 @@
           "vm_name": "test-cloned",
           "vm_new_id": "3000"
         }
+      },
+      "VmConfigResult": {
+        "properties": {
+          "vmid": {
+            "type": "integer",
+            "title": "Vmid"
+          },
+          "node": {
+            "type": "string",
+            "title": "Node"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "qemu",
+              "lxc"
+            ],
+            "title": "Type",
+            "default": "qemu"
+          },
+          "config": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Config"
+          }
+        },
+        "type": "object",
+        "required": [
+          "vmid",
+          "node",
+          "config"
+        ],
+        "title": "VmConfigResult",
+        "description": "Raw PVE guest config (net0/net1/ipconfig*, cores, memory, ...). The UI\nimport flow parses net* to reconstruct per-NIC bridge/network edges (#79)."
       },
       "VmCreateItemReply": {
         "properties": {

--- a/tests/core/test_inventory_writer.py
+++ b/tests/core/test_inventory_writer.py
@@ -101,6 +101,79 @@ def test_skips_non_host_node_kinds(tmp_path):
         "Network nodes must not appear as inventory hosts"
 
 
+def _write(topology, tmp_path, **kw):
+    out = tmp_path / "hosts.yml"
+    write_inventory(
+        topology=topology, codename="X", proxmox_address="10.0.0.1",
+        ssh_keys_dir=tmp_path, dest=out, **kw,
+    )
+    return yaml.safe_load(out.read_text())
+
+
+def test_ansible_host_derives_from_bound_static_network_cidr(tmp_path):
+    """A host NIC's node_ref points to a network node with a static cidr;
+    ansible_host is derived from that cidr (network addr + 200 + seq), not the
+    hardcoded 192.168.{bridge_base} scheme."""
+    topology = {
+        "schema_version": "1.0", "kind": "gamenet", "bridge_base": 140,
+        "nodes": [
+            {"id": "net-custom", "kind": "network",
+             "replication": {"scope": "shared"}, "cidr": "10.50.0.0/24"},
+            {"id": "host-01", "kind": "vm", "role": "admin",
+             "replication": {"scope": "shared"}, "template_vmid": 9001,
+             "config": {}, "networks": [{"node_ref": "net-custom"}],
+             "attachments": []},
+        ],
+    }
+    inv = _write(topology, tmp_path, team_count=1)
+    admin = inv["all"]["children"]["r42_admin"]["hosts"]
+    host = next(h for h in admin if "host-01" in h)
+    assert admin[host]["ansible_host"] == "10.50.0.200"
+
+
+def test_explicit_nic_ip_overrides_network_derivation(tmp_path):
+    """An explicit NIC ip takes precedence over node_ref cidr derivation."""
+    topology = {
+        "schema_version": "1.0", "kind": "gamenet", "bridge_base": 140,
+        "nodes": [
+            {"id": "net-custom", "kind": "network",
+             "replication": {"scope": "shared"}, "cidr": "10.50.0.0/24"},
+            {"id": "host-01", "kind": "vm", "role": "admin",
+             "replication": {"scope": "shared"}, "template_vmid": 9001,
+             "config": {}, "networks": [{"node_ref": "net-custom", "ip": "10.50.0.42"}],
+             "attachments": []},
+        ],
+    }
+    inv = _write(topology, tmp_path, team_count=1)
+    admin = inv["all"]["children"]["r42_admin"]["hosts"]
+    host = next(h for h in admin if "host-01" in h)
+    assert admin[host]["ansible_host"] == "10.50.0.42"
+
+
+def test_ansible_host_derives_from_per_team_cidr_template(tmp_path):
+    """A per-team host bound to a per-team network with a node-level
+    cidr_template resolves the cidr per team id and derives the host ip."""
+    topology = {
+        "schema_version": "1.0", "kind": "gamenet", "bridge_base": 140,
+        "nodes": [
+            {"id": "team-net", "kind": "network",
+             "replication": {"scope": "per_team"},
+             "cidr_template": "10.{{ bridge_base + team_id }}.0.0/16"},
+            {"id": "box", "kind": "vm", "role": "team",
+             "replication": {"scope": "per_team"}, "template_vmid": 9020,
+             "config": {}, "networks": [{"node_ref": "team-net"}],
+             "attachments": []},
+        ],
+    }
+    inv = _write(topology, tmp_path, team_count=2)
+    blank = inv["all"]["children"]["r42_blank_group"]["hosts"]
+    t1 = next(h for h in blank if "1-box" in h)
+    t2 = next(h for h in blank if "2-box" in h)
+    # team1 -> 10.141.0.0/16 + 200 -> 10.141.0.200 ; team2 -> 10.142.0.200
+    assert blank[t1]["ansible_host"] == "10.141.0.200"
+    assert blank[t2]["ansible_host"] == "10.142.0.200"
+
+
 def test_rejects_node_without_role(tmp_path):
     """VM/LXC nodes MUST have a role; preflight catches this but inventory_writer
     is also a defense layer."""

--- a/tests/core/test_inventory_writer.py
+++ b/tests/core/test_inventory_writer.py
@@ -174,6 +174,62 @@ def test_ansible_host_derives_from_per_team_cidr_template(tmp_path):
     assert blank[t2]["ansible_host"] == "10.142.0.200"
 
 
+def test_host_gets_cloudinit_network_vars_from_bound_network(tmp_path):
+    """A host bound to a network exposes r42_ci_netmask/r42_ci_gateway/
+    r42_net_bridge (resolved from that network) for the playbook's cloud-init —
+    single source of truth, no playbook-side recompute."""
+    topology = {
+        "schema_version": "1.0", "kind": "gamenet", "bridge_base": 140,
+        "nodes": [
+            {"id": "net-a", "kind": "network", "replication": {"scope": "shared"},
+             "cidr": "10.20.0.0/24", "gateway": "10.20.0.254", "bridge": "vmbr80"},
+            {"id": "host-01", "kind": "vm", "role": "admin",
+             "replication": {"scope": "shared"}, "template_vmid": 9001,
+             "config": {}, "networks": [{"node_ref": "net-a"}], "attachments": []},
+        ],
+    }
+    inv = _write(topology, tmp_path, team_count=1)
+    admin = inv["all"]["children"]["r42_admin"]["hosts"]
+    host = admin[next(h for h in admin if "host-01" in h)]
+    assert host["ansible_host"] == "10.20.0.200"
+    assert host["r42_ci_netmask"] == 24
+    assert host["r42_ci_gateway"] == "10.20.0.254"
+    assert host["r42_net_bridge"] == "vmbr80"
+
+
+def test_inventory_exposes_network_map(tmp_path):
+    """inventory carries all.vars.r42_network_map: per network id + team, the
+    resolved {bridge, cidr, gateway} the playbook needs to create bridges."""
+    topology = {
+        "schema_version": "1.0", "kind": "gamenet", "bridge_base": 140,
+        "nodes": [
+            {"id": "team-net", "kind": "network", "replication": {"scope": "per_team"},
+             "cidr_template": "10.{{ bridge_base + team_id }}.0.0/16",
+             "bridge_template": "vmbr{{ bridge_base + team_id }}",
+             "gateway_template": "10.{{ bridge_base + team_id }}.0.1"},
+        ],
+    }
+    inv = _write(topology, tmp_path, team_count=2)
+    nmap = inv["all"]["vars"]["r42_network_map"]
+    assert nmap["team-net"]["1"] == {
+        "bridge": "vmbr141", "cidr": "10.141.0.0/16", "gateway": "10.141.0.1"}
+    assert nmap["team-net"]["2"] == {
+        "bridge": "vmbr142", "cidr": "10.142.0.0/16", "gateway": "10.142.0.1"}
+
+
+def test_host_without_network_keeps_legacy_cloudinit_vars(tmp_path):
+    """Backward-compat: a host with no networks[] falls back to the existing
+    192.168.{bridge_base+team} scheme for ci vars."""
+    topology = json.loads((FIXTURES / "02-multi-team.json").read_text())
+    inv = _write(topology, tmp_path, team_count=2)
+    blank = inv["all"]["children"]["r42_blank_group"]["hosts"]
+    h = blank[next(host for host in blank if "1-trainee" in host)]
+    assert h["ansible_host"] == "192.168.141.200"
+    assert h["r42_ci_netmask"] == 24
+    assert h["r42_ci_gateway"] == "192.168.141.1"
+    assert h["r42_net_bridge"] == "vmbr141"
+
+
 def test_rejects_node_without_role(tmp_path):
     """VM/LXC nodes MUST have a role; preflight catches this but inventory_writer
     is also a defense layer."""

--- a/tests/integration/test_universal_deploy_smoke.py
+++ b/tests/integration/test_universal_deploy_smoke.py
@@ -93,7 +93,7 @@ async def _build_universal_attempt(tmp_path: Path, ws: Path,
                      auth_kind="none"))
         s.add(ProxmoxHost(
             id="h", name="n", api_url="https://10.0.0.5:8006",
-            node_name="n", token_ref="t",
+            node_name="n", token_ref="root@pam!range42-backend=secret123",
         ))
         await s.commit()
     async with dbmod.get_session_factory()() as s:
@@ -216,6 +216,14 @@ async def test_universal_smoke_with_capturing_runner(tmp_path, monkeypatch):
     assert extravars["r42_playbook_path"].endswith(
         "scenarios/_universal/main.yml"
     )
+
+    # ASSERT: Proxmox API creds for the playbook's node-network tasks are
+    # derived from the host (token_ref format: user!tokenid=secret).
+    assert extravars["proxmox_api_host"] == "10.0.0.5:8006"
+    assert extravars["proxmox_node"] == "n"
+    assert extravars["proxmox_api_user"] == "root@pam"
+    assert extravars["proxmox_api_token_id"] == "range42-backend"
+    assert extravars["proxmox_api_token_secret"] == "secret123"
 
     # ASSERT: the stubbed checkout dropped topology.json into ws/project/
     assert (ws / "project" / "topology.json").is_file(), \

--- a/tests/routes/test_proxmox_vms.py
+++ b/tests/routes/test_proxmox_vms.py
@@ -68,6 +68,13 @@ class _FakeProxmox:
             return _FakeResp(200, [
                 {"vmid": 200, "name": "ct-1", "status": "stopped"},
             ])
+        if url.endswith("/config"):
+            return _FakeResp(200, {
+                "net0": "virtio=AA:BB:CC:DD:EE:FF,bridge=vmbr142,firewall=1",
+                "net1": "virtio=11:22:33:44:55:66,bridge=vmbr140",
+                "ipconfig0": "ip=192.168.142.50/24,gw=192.168.142.1",
+                "cores": 2, "memory": 2048,
+            })
         if "/tasks/" in url and url.endswith("/status"):
             return _FakeResp(200, {
                 "upid": "UPID:pve01:0001:delete::",
@@ -113,6 +120,28 @@ async def test_list_host_vms_merges_qemu_and_lxc(tmp_path, monkeypatch):
             assert byid[200]["type"] == "lxc"
             # trailing slash in api_url must not produce a double slash
             assert any(u == "https://pve01:8006/api2/json/nodes/pve01/qemu"
+                       for (_, u, *_) in _FakeProxmox.calls)
+    finally:
+        await dbmod.dispose_engine()
+
+
+@pytest.mark.asyncio
+async def test_vm_config_returns_nic_bridges(tmp_path, monkeypatch):
+    app, dbmod = await _boot(tmp_path, monkeypatch)
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeProxmox)
+    _FakeProxmox.calls = []
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            hid = await _create_host(c)
+            r = await c.get(f"/v1/proxmox/hosts/{hid}/vms/4001/config")
+            assert r.status_code == 200, r.text
+            body = r.json()
+            assert body["vmid"] == 4001
+            assert body["node"] == "pve01"
+            assert body["type"] == "qemu"
+            assert "bridge=vmbr142" in body["config"]["net0"]
+            assert "bridge=vmbr140" in body["config"]["net1"]
+            assert any(u.endswith("/qemu/4001/config")
                        for (_, u, *_) in _FakeProxmox.calls)
     finally:
         await dbmod.dispose_engine()


### PR DESCRIPTION
## What

Backend half of the "drawn networks actually provision" epic — makes the canvas's network definitions authoritative end-to-end. Five commits, all TDD, full overlay+core suites green (the one unrelated `test_alembic` failure is pre-existing: system `alembic` on SQLAlchemy 1.x vs project 2.x).

1. **`d4edbd7` / `673ad00` — reconcile `expand_replication` to the canonical schema (#84).** Network templates (`cidr_template`/`bridge_template`/`gateway_template`) are now read at **node level** and rendered with the canonical Jinja `{{ bridge_base + team_id }}` form (legacy `{N+team_id}` still accepted). Byte-parity with the deployer-ui TS expander, enforced by the shared vector harness. Fixes a 3-way schema↔impl divergence (location, placeholder syntax, vlan field).
2. **`b5afd2b` — `bridge_base` null/non-int falls back to 140 (TS parity).** Caught by a Sonnet verification pass: Python crashed where TS defaulted. Also adds node-level `gateway_template` to the schema/Pydantic (it was rendered but would fail strict validation).
3. **`b779a05` — derive `ansible_host` from the bound network CIDR (#73).** A host NIC's `node_ref` resolves to its network's `cidr` (per-team rendered via the *same* canonical renderer). Precedence: explicit NIC `ip` > `node_ref` CIDR > legacy `192.168.{bridge_base+team}` fallback.
4. **`ca063ab` — emit per-host cloud-init net vars + `r42_network_map`.** Backend becomes the single source of resolved network values so the `_universal` playbook stops recomputing them: each host carries `r42_ci_netmask`/`r42_ci_gateway`/`r42_net_bridge`; `all.vars.r42_network_map` carries per-network/per-team resolved `bridge`/`cidr`/`gateway`.

## Companion PRs / context
- **range42-playbooks#90** consumes `r42_network_map` + the per-host ci vars (slices 4/5). It depends on this PR.
- deployer-ui counterparts (TS expander, schema, vectors) are already on `dev` per that repo's direct-commit convention.
- Verified by two Sonnet review agents (parity + regressions); both real findings fixed here.

## Test
`pytest tests/overlay tests/core` green (excluding the pre-existing `test_alembic` env failure). Deployer-ui full unit suite: 539 passed.