### PR TITLE
feat(v1/proxmox): storage + per-VM snapshot endpoints (direct httpx)

### DIFF
--- a/app/routes/v1/proxmox/__init__.py
+++ b/app/routes/v1/proxmox/__init__.py
@@ -1,8 +1,10 @@
 from fastapi import APIRouter
 
 from app.routes.v1.proxmox.hosts import router as hosts_router
+from app.routes.v1.proxmox.storage import router as storage_router
 from app.routes.v1.proxmox.vms import router as vms_router
 
 router = APIRouter(prefix="/proxmox", tags=["v1 proxmox"])
 router.include_router(hosts_router)
 router.include_router(vms_router)
+router.include_router(storage_router)

--- a/app/routes/v1/proxmox/__init__.py
+++ b/app/routes/v1/proxmox/__init__.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter
 
 from app.routes.v1.proxmox.hosts import router as hosts_router
+from app.routes.v1.proxmox.snapshots import router as snapshots_router
 from app.routes.v1.proxmox.storage import router as storage_router
 from app.routes.v1.proxmox.vms import router as vms_router
 
@@ -8,3 +9,4 @@ router = APIRouter(prefix="/proxmox", tags=["v1 proxmox"])
 router.include_router(hosts_router)
 router.include_router(vms_router)
 router.include_router(storage_router)
+router.include_router(snapshots_router)

--- a/app/routes/v1/proxmox/_helpers.py
+++ b/app/routes/v1/proxmox/_helpers.py
@@ -1,0 +1,80 @@
+"""Shared helpers for the v1 proxmox route modules (vms/hosts/storage/snapshots).
+
+Talk to PVE directly over httpx with a registered host's token. Extracted so
+sibling modules reuse one copy instead of cross-importing privates.
+"""
+from __future__ import annotations
+
+import json
+
+import httpx
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db import get_session_factory
+from app.core.errors import AuthFailedError, Range42Error, VmidProtectedError
+from app.core.logging import get_logger
+from app.core.models import ProxmoxHost
+from app.core.vmid_guard import VmidProtectedError as GuardVmidProtected
+from app.core.vmid_guard import assert_vmid_safe
+
+log = get_logger(__name__)
+
+
+async def _session() -> AsyncSession:
+    async with get_session_factory()() as session:
+        yield session
+
+
+async def _get_host(host_id: str, session: AsyncSession) -> ProxmoxHost:
+    row = (
+        await session.execute(select(ProxmoxHost).where(ProxmoxHost.id == host_id))
+    ).scalar_one_or_none()
+    if row is None:
+        raise Range42Error(
+            error="not_found", code="NOT_FOUND", status=404,
+            message=f"Host {host_id} not found",
+        )
+    return row
+
+
+def _auth_headers(row: ProxmoxHost) -> dict[str, str]:
+    return {"Authorization": f"PVEAPIToken={row.token_ref}"}
+
+
+def _assert_vmid_safe(row: ProxmoxHost, vmid: int, action: str) -> None:
+    overrides = (
+        json.loads(row.protected_vmids_override_json)
+        if row.protected_vmids_override_json else None
+    )
+    try:
+        assert_vmid_safe(vmid, host_overrides=overrides)
+    except GuardVmidProtected as e:
+        raise VmidProtectedError(
+            message=f"VMID {vmid} is protected; '{action}' is refused",
+            details=e.details,
+        ) from e
+
+
+def _unreachable(row: ProxmoxHost, err: Exception) -> Range42Error:
+    log.warning("proxmox unreachable", host=row.id, err=str(err))
+    return Range42Error(
+        error="upstream_error", code="PROXMOX_UNREACHABLE", status=502,
+        message=f"Proxmox host {row.name} is unreachable",
+        details=[{"field": "api_url", "reason": str(err)[:200]}],
+    )
+
+
+def _raise_for_pve(row: ProxmoxHost, r: httpx.Response, action: str = "request") -> None:
+    """Map a non-200 PVE response to the canonical error classes."""
+    if r.status_code in (401, 403):
+        raise AuthFailedError(details=[{
+            "field": "token_ref",
+            "reason": f"Proxmox API rejected credentials ({r.status_code})",
+        }])
+    if r.status_code != 200:
+        raise Range42Error(
+            error="upstream_error", code="PROXMOX_ERROR", status=502,
+            message=f"Proxmox returned {r.status_code} for {action}",
+            details=[{"field": "host", "reason": (r.text or "")[:300]}],
+        )

--- a/app/routes/v1/proxmox/hosts.py
+++ b/app/routes/v1/proxmox/hosts.py
@@ -11,20 +11,15 @@ from fastapi import APIRouter, Depends, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.db import get_session_factory
 from app.core.errors import AuthFailedError, Range42Error
 from app.core.logging import get_logger
 from app.core.models import ProxmoxHost
+from app.routes.v1.proxmox._helpers import _session
 from app.schemas.v1.common import Page
 from app.schemas.v1.proxmox import HostHealth, HostIn, HostOut
 
 router = APIRouter()
 log = get_logger(__name__)
-
-
-async def _session() -> AsyncSession:
-    async with get_session_factory()() as session:
-        yield session
 
 
 def _row_to_out(row: ProxmoxHost) -> HostOut:

--- a/app/routes/v1/proxmox/snapshots.py
+++ b/app/routes/v1/proxmox/snapshots.py
@@ -1,0 +1,58 @@
+"""/v1/proxmox/hosts/{id}/vms/{vmid}/snapshots — per-VM PVE snapshots.
+
+Direct PVE httpx. NET-NEW vs v0: supports vmtype=lxc and the vmstate flag
+(v0 was qemu-only, no vmstate). create/delete/rollback return UPIDs.
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+import httpx
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.routes.v1.proxmox._helpers import (
+    _assert_vmid_safe, _auth_headers, _get_host, _raise_for_pve, _session,
+    _unreachable,
+)
+from app.schemas.v1.common import Page
+from app.schemas.v1.proxmox import SnapshotItem, VmActionResult
+
+router = APIRouter()
+
+
+def _snap_base(row, vmtype: str, vmid: int) -> str:
+    return (
+        f"{row.api_url.rstrip('/')}/api2/json/nodes/{row.node_name}"
+        f"/{vmtype}/{vmid}/snapshot"
+    )
+
+
+@router.get(
+    "/hosts/{host_id}/vms/{vmid}/snapshots", response_model=Page[SnapshotItem]
+)
+async def list_snapshots(
+    host_id: str,
+    vmid: int,
+    vmtype: Literal["qemu", "lxc"] = "qemu",
+    session: AsyncSession = Depends(_session),
+):
+    row = await _get_host(host_id, session)
+    try:
+        async with httpx.AsyncClient(verify=False, timeout=15) as cli:
+            r = await cli.get(_snap_base(row, vmtype, vmid), headers=_auth_headers(row))
+    except httpx.RequestError as e:
+        raise _unreachable(row, e) from e
+    _raise_for_pve(row, r, "snapshot list")
+    data = r.json().get("data", []) or []
+    items = [
+        SnapshotItem(
+            name=d["name"], description=d.get("description"),
+            snaptime=d.get("snaptime"),
+            vmstate=bool(d["vmstate"]) if d.get("vmstate") is not None else None,
+            parent=d.get("parent"),
+        )
+        for d in data
+        if d.get("name") and d["name"] != "current"
+    ]
+    return Page(items=items, total=len(items))

--- a/app/routes/v1/proxmox/snapshots.py
+++ b/app/routes/v1/proxmox/snapshots.py
@@ -80,3 +80,24 @@ async def create_snapshot(
         raise _unreachable(row, e) from e
     _raise_for_pve(row, r, "snapshot create")
     return VmActionResult(status="accepted", upid=r.json().get("data"))
+
+
+@router.delete(
+    "/hosts/{host_id}/vms/{vmid}/snapshots/{name}", response_model=VmActionResult
+)
+async def delete_snapshot(
+    host_id: str,
+    vmid: int,
+    name: str,
+    vmtype: Literal["qemu", "lxc"] = "qemu",
+    session: AsyncSession = Depends(_session),
+):
+    row = await _get_host(host_id, session)
+    url = f"{_snap_base(row, vmtype, vmid)}/{name}"
+    try:
+        async with httpx.AsyncClient(verify=False, timeout=15) as cli:
+            r = await cli.delete(url, headers=_auth_headers(row))
+    except httpx.RequestError as e:
+        raise _unreachable(row, e) from e
+    _raise_for_pve(row, r, "snapshot delete")
+    return VmActionResult(status="accepted", upid=r.json().get("data"))

--- a/app/routes/v1/proxmox/snapshots.py
+++ b/app/routes/v1/proxmox/snapshots.py
@@ -16,7 +16,7 @@ from app.routes.v1.proxmox._helpers import (
     _unreachable,
 )
 from app.schemas.v1.common import Page
-from app.schemas.v1.proxmox import SnapshotItem, VmActionResult
+from app.schemas.v1.proxmox import SnapshotItem, SnapshotCreateIn, VmActionResult
 
 router = APIRouter()
 
@@ -56,3 +56,27 @@ async def list_snapshots(
         if d.get("name") and d["name"] != "current"
     ]
     return Page(items=items, total=len(items))
+
+
+@router.post("/hosts/{host_id}/vms/{vmid}/snapshots", response_model=VmActionResult)
+async def create_snapshot(
+    host_id: str,
+    vmid: int,
+    body: SnapshotCreateIn,
+    vmtype: Literal["qemu", "lxc"] = "qemu",
+    session: AsyncSession = Depends(_session),
+):
+    row = await _get_host(host_id, session)
+    form: dict[str, str | int] = {"snapname": body.snapname}
+    if body.description:
+        form["description"] = body.description
+    if body.vmstate is not None:
+        form["vmstate"] = 1 if body.vmstate else 0
+    try:
+        async with httpx.AsyncClient(verify=False, timeout=15) as cli:
+            r = await cli.post(_snap_base(row, vmtype, vmid),
+                               headers=_auth_headers(row), data=form)
+    except httpx.RequestError as e:
+        raise _unreachable(row, e) from e
+    _raise_for_pve(row, r, "snapshot create")
+    return VmActionResult(status="accepted", upid=r.json().get("data"))

--- a/app/routes/v1/proxmox/snapshots.py
+++ b/app/routes/v1/proxmox/snapshots.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from typing import Literal
 
 import httpx
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Path
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.routes.v1.proxmox._helpers import (
@@ -68,7 +68,7 @@ async def create_snapshot(
 ):
     row = await _get_host(host_id, session)
     form: dict[str, str | int] = {"snapname": body.snapname}
-    if body.description:
+    if body.description is not None:
         form["description"] = body.description
     if body.vmstate is not None:
         form["vmstate"] = 1 if body.vmstate else 0
@@ -88,8 +88,8 @@ async def create_snapshot(
 async def delete_snapshot(
     host_id: str,
     vmid: int,
-    name: str,
     vmtype: Literal["qemu", "lxc"] = "qemu",
+    name: str = Path(pattern=r"^[A-Za-z0-9_][A-Za-z0-9._-]*$"),
     session: AsyncSession = Depends(_session),
 ):
     row = await _get_host(host_id, session)
@@ -110,8 +110,8 @@ async def delete_snapshot(
 async def rollback_snapshot(
     host_id: str,
     vmid: int,
-    name: str,
     vmtype: Literal["qemu", "lxc"] = "qemu",
+    name: str = Path(pattern=r"^[A-Za-z0-9_][A-Za-z0-9._-]*$"),
     session: AsyncSession = Depends(_session),
 ):
     row = await _get_host(host_id, session)

--- a/app/routes/v1/proxmox/snapshots.py
+++ b/app/routes/v1/proxmox/snapshots.py
@@ -70,7 +70,9 @@ async def create_snapshot(
     form: dict[str, str | int] = {"snapname": body.snapname}
     if body.description is not None:
         form["description"] = body.description
-    if body.vmstate is not None:
+    # vmstate (save running RAM state) is a qemu-only PVE option; PVE rejects it
+    # on /lxc/.../snapshot, so omit it for LXC (matches community.proxmox).
+    if vmtype == "qemu" and body.vmstate is not None:
         form["vmstate"] = 1 if body.vmstate else 0
     try:
         async with httpx.AsyncClient(verify=False, timeout=15) as cli:

--- a/app/routes/v1/proxmox/snapshots.py
+++ b/app/routes/v1/proxmox/snapshots.py
@@ -101,3 +101,26 @@ async def delete_snapshot(
         raise _unreachable(row, e) from e
     _raise_for_pve(row, r, "snapshot delete")
     return VmActionResult(status="accepted", upid=r.json().get("data"))
+
+
+@router.post(
+    "/hosts/{host_id}/vms/{vmid}/snapshots/{name}/rollback",
+    response_model=VmActionResult,
+)
+async def rollback_snapshot(
+    host_id: str,
+    vmid: int,
+    name: str,
+    vmtype: Literal["qemu", "lxc"] = "qemu",
+    session: AsyncSession = Depends(_session),
+):
+    row = await _get_host(host_id, session)
+    _assert_vmid_safe(row, vmid, "rollback")
+    url = f"{_snap_base(row, vmtype, vmid)}/{name}/rollback"
+    try:
+        async with httpx.AsyncClient(verify=False, timeout=15) as cli:
+            r = await cli.post(url, headers=_auth_headers(row))
+    except httpx.RequestError as e:
+        raise _unreachable(row, e) from e
+    _raise_for_pve(row, r, "snapshot rollback")
+    return VmActionResult(status="accepted", upid=r.json().get("data"))

--- a/app/routes/v1/proxmox/storage.py
+++ b/app/routes/v1/proxmox/storage.py
@@ -14,7 +14,7 @@ from app.routes.v1.proxmox._helpers import (
     _auth_headers, _get_host, _raise_for_pve, _session, _unreachable,
 )
 from app.schemas.v1.common import Page
-from app.schemas.v1.proxmox import StorageContent, StoragePool
+from app.schemas.v1.proxmox import DownloadUrlIn, StorageContent, StoragePool, VmActionResult
 
 router = APIRouter()
 
@@ -80,3 +80,34 @@ async def list_storage(host_id: str, session: AsyncSession = Depends(_session)):
         for d in data
     ]
     return Page(items=items, total=len(items))
+
+
+@router.post(
+    "/hosts/{host_id}/storage/{store}/download-url",
+    response_model=VmActionResult,
+)
+async def storage_download_url(
+    host_id: str,
+    store: str,
+    body: DownloadUrlIn,
+    session: AsyncSession = Depends(_session),
+):
+    row = await _get_host(host_id, session)
+    url = (
+        f"{row.api_url.rstrip('/')}/api2/json/nodes/{row.node_name}"
+        f"/storage/{store}/download-url"
+    )
+    form: dict[str, str] = {
+        "content": body.content, "filename": body.filename, "url": body.url,
+    }
+    if body.checksum:
+        form["checksum"] = body.checksum
+    if body.checksum_algorithm:
+        form["checksum-algorithm"] = body.checksum_algorithm
+    try:
+        async with httpx.AsyncClient(verify=False, timeout=15) as cli:
+            r = await cli.post(url, headers=_auth_headers(row), data=form)
+    except httpx.RequestError as e:
+        raise _unreachable(row, e) from e
+    _raise_for_pve(row, r, "download-url")
+    return VmActionResult(status="accepted", upid=r.json().get("data"))

--- a/app/routes/v1/proxmox/storage.py
+++ b/app/routes/v1/proxmox/storage.py
@@ -1,0 +1,41 @@
+"""/v1/proxmox/hosts/{id}/storage — pools + content listing + download-url.
+
+Direct PVE httpx. Replaces the v0 Ansible-driven storage surface.
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+import httpx
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.routes.v1.proxmox._helpers import (
+    _auth_headers, _get_host, _raise_for_pve, _session, _unreachable,
+)
+from app.schemas.v1.common import Page
+from app.schemas.v1.proxmox import StoragePool
+
+router = APIRouter()
+
+
+@router.get("/hosts/{host_id}/storage", response_model=Page[StoragePool])
+async def list_storage(host_id: str, session: AsyncSession = Depends(_session)):
+    row = await _get_host(host_id, session)
+    url = f"{row.api_url.rstrip('/')}/api2/json/nodes/{row.node_name}/storage"
+    try:
+        async with httpx.AsyncClient(verify=False, timeout=15) as cli:
+            r = await cli.get(url, headers=_auth_headers(row))
+    except httpx.RequestError as e:
+        raise _unreachable(row, e) from e
+    _raise_for_pve(row, r, "storage list")
+    data = r.json().get("data", []) or []
+    items = [
+        StoragePool(
+            storage=d.get("storage"), type=d.get("type"), content=d.get("content"),
+            total=d.get("total"), used=d.get("used"), avail=d.get("avail"),
+            active=bool(d["active"]) if d.get("active") is not None else None,
+        )
+        for d in data
+    ]
+    return Page(items=items, total=len(items))

--- a/app/routes/v1/proxmox/storage.py
+++ b/app/routes/v1/proxmox/storage.py
@@ -14,9 +14,50 @@ from app.routes.v1.proxmox._helpers import (
     _auth_headers, _get_host, _raise_for_pve, _session, _unreachable,
 )
 from app.schemas.v1.common import Page
-from app.schemas.v1.proxmox import StoragePool
+from app.schemas.v1.proxmox import StorageContent, StoragePool
 
 router = APIRouter()
+
+
+def _volid_name(volid: str) -> str:
+    """'local:iso/ubuntu.iso' -> 'ubuntu.iso'; 'local:vztmpl/x.tar.zst' -> 'x.tar.zst'."""
+    if "/" in volid:
+        return volid.rsplit("/", 1)[-1]
+    return volid.rsplit(":", 1)[-1]
+
+
+@router.get(
+    "/hosts/{host_id}/storage/{store}/content",
+    response_model=Page[StorageContent],
+)
+async def list_storage_content(
+    host_id: str,
+    store: str,
+    content: Literal["iso", "vztmpl"] = "iso",
+    session: AsyncSession = Depends(_session),
+):
+    row = await _get_host(host_id, session)
+    url = (
+        f"{row.api_url.rstrip('/')}/api2/json/nodes/{row.node_name}"
+        f"/storage/{store}/content"
+    )
+    try:
+        async with httpx.AsyncClient(verify=False, timeout=15) as cli:
+            r = await cli.get(url, headers=_auth_headers(row),
+                              params={"content": content})
+    except httpx.RequestError as e:
+        raise _unreachable(row, e) from e
+    _raise_for_pve(row, r, "storage content")
+    data = r.json().get("data", []) or []
+    items = [
+        StorageContent(
+            volid=d["volid"], name=_volid_name(d["volid"]),
+            content=d.get("content", content), size=d.get("size"),
+            format=d.get("format"), vmid=d.get("vmid"),
+        )
+        for d in data
+    ]
+    return Page(items=items, total=len(items))
 
 
 @router.get("/hosts/{host_id}/storage", response_model=Page[StoragePool])

--- a/app/routes/v1/proxmox/storage.py
+++ b/app/routes/v1/proxmox/storage.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import Literal
 
 import httpx
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Path
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.routes.v1.proxmox._helpers import (
@@ -32,8 +32,8 @@ def _volid_name(volid: str) -> str:
 )
 async def list_storage_content(
     host_id: str,
-    store: str,
     content: Literal["iso", "vztmpl"] = "iso",
+    store: str = Path(pattern=r"^[A-Za-z0-9][A-Za-z0-9._-]*$"),
     session: AsyncSession = Depends(_session),
 ):
     row = await _get_host(host_id, session)
@@ -88,8 +88,8 @@ async def list_storage(host_id: str, session: AsyncSession = Depends(_session)):
 )
 async def storage_download_url(
     host_id: str,
-    store: str,
     body: DownloadUrlIn,
+    store: str = Path(pattern=r"^[A-Za-z0-9][A-Za-z0-9._-]*$"),
     session: AsyncSession = Depends(_session),
 ):
     row = await _get_host(host_id, session)
@@ -100,9 +100,9 @@ async def storage_download_url(
     form: dict[str, str] = {
         "content": body.content, "filename": body.filename, "url": body.url,
     }
-    if body.checksum:
+    if body.checksum is not None:
         form["checksum"] = body.checksum
-    if body.checksum_algorithm:
+    if body.checksum_algorithm is not None:
         form["checksum-algorithm"] = body.checksum_algorithm
     try:
         async with httpx.AsyncClient(verify=False, timeout=15) as cli:

--- a/app/routes/v1/proxmox/vms.py
+++ b/app/routes/v1/proxmox/vms.py
@@ -6,21 +6,22 @@ VM listing and start/stop/pause/resume.
 """
 from __future__ import annotations
 
-import json
 from typing import Literal
 from urllib.parse import quote
 
 import httpx
 from fastapi import APIRouter, Depends
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.db import get_session_factory
-from app.core.errors import AuthFailedError, Range42Error, VmidProtectedError
+from app.core.errors import AuthFailedError, Range42Error
 from app.core.logging import get_logger
-from app.core.models import ProxmoxHost
-from app.core.vmid_guard import VmidProtectedError as GuardVmidProtected
-from app.core.vmid_guard import assert_vmid_safe
+from app.routes.v1.proxmox._helpers import (
+    _assert_vmid_safe,
+    _auth_headers,
+    _get_host,
+    _session,
+    _unreachable,
+)
 from app.schemas.v1.common import Page
 from app.schemas.v1.proxmox import TaskStatus, VmActionResult, VmSummary
 
@@ -31,48 +32,6 @@ log = get_logger(__name__)
 # the rest can disrupt a running guest.
 _ALLOWED_ACTIONS = {"start", "stop", "shutdown", "suspend", "resume", "reboot"}
 _DESTRUCTIVE_ACTIONS = {"stop", "shutdown", "suspend", "reboot"}
-
-
-async def _session() -> AsyncSession:
-    async with get_session_factory()() as session:
-        yield session
-
-
-async def _get_host(host_id: str, session: AsyncSession) -> ProxmoxHost:
-    row = (
-        await session.execute(
-            select(ProxmoxHost).where(ProxmoxHost.id == host_id)
-        )
-    ).scalar_one_or_none()
-    if row is None:
-        raise Range42Error(
-            error="not_found",
-            code="NOT_FOUND",
-            status=404,
-            message=f"Host {host_id} not found",
-        )
-    return row
-
-
-def _auth_headers(row: ProxmoxHost) -> dict[str, str]:
-    return {"Authorization": f"PVEAPIToken={row.token_ref}"}
-
-
-def _assert_vmid_safe(row: ProxmoxHost, vmid: int, action: str) -> None:
-    """Refuse destructive actions on protected VMIDs (canonical ranges + per-host
-    overrides). `action` only feeds the error message."""
-    overrides = (
-        json.loads(row.protected_vmids_override_json)
-        if row.protected_vmids_override_json
-        else None
-    )
-    try:
-        assert_vmid_safe(vmid, host_overrides=overrides)
-    except GuardVmidProtected as e:
-        raise VmidProtectedError(
-            message=f"VMID {vmid} is protected; '{action}' is refused",
-            details=e.details,
-        ) from e
 
 
 @router.get("/hosts/{host_id}/vms", response_model=Page[VmSummary])
@@ -161,17 +120,6 @@ async def vm_status_action(
             details=[{"field": "vmid", "reason": r.text[:300]}],
         )
     return VmActionResult(status="accepted", upid=r.json().get("data"))
-
-
-def _unreachable(row: ProxmoxHost, err: Exception) -> Range42Error:
-    log.warning("proxmox unreachable", host=row.id, err=str(err))
-    return Range42Error(
-        error="upstream_error",
-        code="PROXMOX_UNREACHABLE",
-        status=502,
-        message=f"Proxmox host {row.name} is unreachable",
-        details=[{"field": "api_url", "reason": str(err)[:200]}],
-    )
 
 
 @router.delete("/hosts/{host_id}/vms/{vmid}", response_model=VmActionResult)

--- a/app/schemas/v1/proxmox.py
+++ b/app/schemas/v1/proxmox.py
@@ -55,3 +55,13 @@ class TaskStatus(BaseModel):
     status: Literal["running", "stopped"]
     exitstatus: str | None = None
     node: str
+
+
+class StoragePool(BaseModel):
+    storage: str
+    type: str
+    content: str | None = None
+    total: int | None = None
+    used: int | None = None
+    avail: int | None = None
+    active: bool | None = None

--- a/app/schemas/v1/proxmox.py
+++ b/app/schemas/v1/proxmox.py
@@ -84,3 +84,11 @@ class DownloadUrlIn(BaseModel):
     url: str
     checksum: str | None = None
     checksum_algorithm: str | None = None
+
+
+class SnapshotItem(BaseModel):
+    name: str
+    description: str | None = None
+    snaptime: int | None = None
+    vmstate: bool | None = None
+    parent: str | None = None

--- a/app/schemas/v1/proxmox.py
+++ b/app/schemas/v1/proxmox.py
@@ -92,3 +92,9 @@ class SnapshotItem(BaseModel):
     snaptime: int | None = None
     vmstate: bool | None = None
     parent: str | None = None
+
+
+class SnapshotCreateIn(BaseModel):
+    snapname: str
+    description: str | None = None
+    vmstate: bool | None = None

--- a/app/schemas/v1/proxmox.py
+++ b/app/schemas/v1/proxmox.py
@@ -1,10 +1,11 @@
 """Proxmox host CRUD + health DTOs."""
 from __future__ import annotations
 
+import re
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel, HttpUrl
+from pydantic import BaseModel, HttpUrl, field_validator
 
 
 class HostIn(BaseModel):
@@ -84,6 +85,20 @@ class DownloadUrlIn(BaseModel):
     url: str
     checksum: str | None = None
     checksum_algorithm: str | None = None
+
+    @field_validator("url")
+    @classmethod
+    def _url_scheme(cls, v: str) -> str:
+        if not (v.startswith("http://") or v.startswith("https://")):
+            raise ValueError("url must be an http(s) URL")
+        return v
+
+    @field_validator("filename")
+    @classmethod
+    def _filename_bare(cls, v: str) -> str:
+        if ".." in v or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", v):
+            raise ValueError("filename must be a bare filename")
+        return v
 
 
 class SnapshotItem(BaseModel):

--- a/app/schemas/v1/proxmox.py
+++ b/app/schemas/v1/proxmox.py
@@ -65,3 +65,14 @@ class StoragePool(BaseModel):
     used: int | None = None
     avail: int | None = None
     active: bool | None = None
+
+
+class StorageContent(BaseModel):
+    """A volume in a storage pool. ``name`` is derived from ``volid`` (PVE does
+    not return it) and is load-bearing for the UI's TemplateBrowser."""
+    volid: str
+    name: str
+    content: str
+    size: int | None = None
+    format: str | None = None
+    vmid: int | None = None

--- a/app/schemas/v1/proxmox.py
+++ b/app/schemas/v1/proxmox.py
@@ -76,3 +76,11 @@ class StorageContent(BaseModel):
     size: int | None = None
     format: str | None = None
     vmid: int | None = None
+
+
+class DownloadUrlIn(BaseModel):
+    content: Literal["iso", "vztmpl"]
+    filename: str
+    url: str
+    checksum: str | None = None
+    checksum_algorithm: str | None = None

--- a/tests/routes/test_proxmox_snapshots.py
+++ b/tests/routes/test_proxmox_snapshots.py
@@ -113,3 +113,27 @@ async def test_list_snapshots_pve_error_maps_502(tmp_path, monkeypatch):
             assert r.json()["code"] == "PROXMOX_ERROR"
     finally:
         await dbmod.dispose_engine()
+
+
+@pytest.mark.asyncio
+async def test_create_snapshot_returns_upid(tmp_path, monkeypatch):
+    app, dbmod = await _boot(tmp_path, monkeypatch)
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeProxmox)
+    _FakeProxmox.calls = []
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            hid = await _create_host(c)
+            r = await c.post(
+                f"/v1/proxmox/hosts/{hid}/vms/200/snapshots",
+                json={"snapname": "s1", "description": "d", "vmstate": True},
+            )
+            assert r.status_code == 200, r.text
+            assert r.json()["upid"].startswith("UPID")
+            posts = [(u, d) for (m, u, d) in _FakeProxmox.calls if m == "POST"]
+            assert posts, "expected a POST to Proxmox"
+            url, data = posts[0]
+            assert url == "https://pve01:8006/api2/json/nodes/pve01/qemu/200/snapshot"
+            assert data["snapname"] == "s1"
+            assert data["vmstate"] == 1
+    finally:
+        await dbmod.dispose_engine()

--- a/tests/routes/test_proxmox_snapshots.py
+++ b/tests/routes/test_proxmox_snapshots.py
@@ -137,3 +137,22 @@ async def test_create_snapshot_returns_upid(tmp_path, monkeypatch):
             assert data["vmstate"] == 1
     finally:
         await dbmod.dispose_engine()
+
+
+@pytest.mark.asyncio
+async def test_delete_snapshot_returns_upid(tmp_path, monkeypatch):
+    app, dbmod = await _boot(tmp_path, monkeypatch)
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeProxmox)
+    _FakeProxmox.calls = []
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            hid = await _create_host(c)
+            r = await c.delete(f"/v1/proxmox/hosts/{hid}/vms/200/snapshots/s1")
+            assert r.status_code == 200, r.text
+            assert r.json()["upid"].startswith("UPID")
+            deletes = [u for (m, u, *_) in _FakeProxmox.calls if m == "DELETE"]
+            assert deletes == [
+                "https://pve01:8006/api2/json/nodes/pve01/qemu/200/snapshot/s1"
+            ]
+    finally:
+        await dbmod.dispose_engine()

--- a/tests/routes/test_proxmox_snapshots.py
+++ b/tests/routes/test_proxmox_snapshots.py
@@ -1,0 +1,115 @@
+"""/v1/proxmox/hosts/{id}/vms/{vmid}/snapshots — per-VM PVE snapshots."""
+import json
+
+import httpx
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+async def _boot(tmp_path, monkeypatch):
+    db = tmp_path / "t.db"
+    monkeypatch.setenv("RANGE42_DB_URL", f"sqlite+aiosqlite:///{db}")
+    monkeypatch.setenv("RANGE42_WORKSPACE_ROOT", str(tmp_path))
+    from importlib import reload
+    from app.core import config as cfg
+    reload(cfg)
+    import app.core.db as dbmod
+    reload(dbmod)
+    from app.core.models import Base
+    engine = dbmod.get_engine()
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    from app.main import create_app
+    return create_app(), dbmod
+
+
+class _FakeResp:
+    def __init__(self, status_code, data):
+        self.status_code = status_code
+        self._data = data
+
+    def json(self):
+        return {"data": self._data}
+
+    @property
+    def text(self):
+        return json.dumps(self._data)
+
+
+class _FakeProxmox:
+    calls: list = []
+
+    def __init__(self, *a, **k):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def get(self, url, headers=None, params=None):
+        _FakeProxmox.calls.append(("GET", url, params))
+        if url.endswith("/snapshot"):
+            return _FakeResp(200, [
+                {"name": "base", "description": "first", "snaptime": 1700000000},
+                {"name": "current", "description": "You are here!"},
+            ])
+        return _FakeResp(404, [])
+
+    async def post(self, url, headers=None, data=None):
+        _FakeProxmox.calls.append(("POST", url, data))
+        return _FakeResp(200, "UPID:pve01:0001:snap::")
+
+    async def delete(self, url, headers=None, params=None):
+        _FakeProxmox.calls.append(("DELETE", url, params))
+        return _FakeResp(200, "UPID:pve01:0002:delsnap::")
+
+
+async def _create_host(c):
+    r = await c.post("/v1/proxmox/hosts", json={
+        "name": "pve01", "api_url": "https://pve01:8006/", "node_name": "pve01",
+        "token_ref": "root@pam!tok=secret", "default_bridge": "vmbr0",
+    })
+    return r.json()["id"]
+
+
+@pytest.mark.asyncio
+async def test_list_snapshots_filters_current(tmp_path, monkeypatch):
+    app, dbmod = await _boot(tmp_path, monkeypatch)
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeProxmox)
+    _FakeProxmox.calls = []
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            hid = await _create_host(c)
+            r = await c.get(f"/v1/proxmox/hosts/{hid}/vms/200/snapshots")
+            assert r.status_code == 200, r.text
+            body = r.json()
+            assert body["total"] == 1
+            assert body["items"][0]["name"] == "base"
+            assert any(
+                u == "https://pve01:8006/api2/json/nodes/pve01/qemu/200/snapshot"
+                for (_, u, *_) in _FakeProxmox.calls)
+    finally:
+        await dbmod.dispose_engine()
+
+
+@pytest.mark.asyncio
+async def test_list_snapshots_pve_error_maps_502(tmp_path, monkeypatch):
+    app, dbmod = await _boot(tmp_path, monkeypatch)
+
+    class _ErrProxmox(_FakeProxmox):
+        async def get(self, url, headers=None, params=None):
+            _FakeProxmox.calls.append(("GET", url, params))
+            return _FakeResp(500, "boom")
+
+    monkeypatch.setattr(httpx, "AsyncClient", _ErrProxmox)
+    _FakeProxmox.calls = []
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            hid = await _create_host(c)
+            r = await c.get(f"/v1/proxmox/hosts/{hid}/vms/200/snapshots")
+            assert r.status_code == 502
+            assert r.json()["code"] == "PROXMOX_ERROR"
+    finally:
+        await dbmod.dispose_engine()

--- a/tests/routes/test_proxmox_snapshots.py
+++ b/tests/routes/test_proxmox_snapshots.py
@@ -220,3 +220,28 @@ async def test_snapshot_rollback_rejects_bad_name(tmp_path, monkeypatch):
             assert r.status_code == 422
     finally:
         await dbmod.dispose_engine()
+
+
+@pytest.mark.asyncio
+async def test_create_lxc_snapshot_omits_vmstate(tmp_path, monkeypatch):
+    # vmstate is a qemu-only PVE option; forwarding it to /lxc/.../snapshot makes
+    # PVE reject the call (502). The create route must drop vmstate for vmtype=lxc.
+    app, dbmod = await _boot(tmp_path, monkeypatch)
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeProxmox)
+    _FakeProxmox.calls = []
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            hid = await _create_host(c)
+            r = await c.post(
+                f"/v1/proxmox/hosts/{hid}/vms/200/snapshots?vmtype=lxc",
+                json={"snapname": "s1", "vmstate": True},
+            )
+            assert r.status_code == 200, r.text
+            posts = [(u, d) for (m, u, d) in _FakeProxmox.calls if m == "POST"]
+            assert posts, "expected a POST to Proxmox"
+            url, data = posts[0]
+            assert "/lxc/200/snapshot" in url
+            assert "vmstate" not in data
+            assert data["snapname"] == "s1"
+    finally:
+        await dbmod.dispose_engine()

--- a/tests/routes/test_proxmox_snapshots.py
+++ b/tests/routes/test_proxmox_snapshots.py
@@ -196,3 +196,27 @@ async def test_rollback_protected_vmid_refused(tmp_path, monkeypatch):
             assert [m for (m, *_) in _FakeProxmox.calls if m == "POST"] == []
     finally:
         await dbmod.dispose_engine()
+
+
+@pytest.mark.asyncio
+async def test_snapshot_delete_rejects_bad_name(tmp_path, monkeypatch):
+    app, dbmod = await _boot(tmp_path, monkeypatch)
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            hid = await _create_host(c)
+            r = await c.delete(f"/v1/proxmox/hosts/{hid}/vms/200/snapshots/e!vil")
+            assert r.status_code == 422
+    finally:
+        await dbmod.dispose_engine()
+
+
+@pytest.mark.asyncio
+async def test_snapshot_rollback_rejects_bad_name(tmp_path, monkeypatch):
+    app, dbmod = await _boot(tmp_path, monkeypatch)
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            hid = await _create_host(c)
+            r = await c.post(f"/v1/proxmox/hosts/{hid}/vms/200/snapshots/e!vil/rollback")
+            assert r.status_code == 422
+    finally:
+        await dbmod.dispose_engine()

--- a/tests/routes/test_proxmox_snapshots.py
+++ b/tests/routes/test_proxmox_snapshots.py
@@ -156,3 +156,43 @@ async def test_delete_snapshot_returns_upid(tmp_path, monkeypatch):
             ]
     finally:
         await dbmod.dispose_engine()
+
+
+@pytest.mark.asyncio
+async def test_rollback_returns_upid(tmp_path, monkeypatch):
+    app, dbmod = await _boot(tmp_path, monkeypatch)
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeProxmox)
+    _FakeProxmox.calls = []
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            hid = await _create_host(c)
+            r = await c.post(
+                f"/v1/proxmox/hosts/{hid}/vms/200/snapshots/s1/rollback"
+            )
+            assert r.status_code == 200, r.text
+            assert r.json()["upid"].startswith("UPID")
+            posts = [u for (m, u, *_) in _FakeProxmox.calls if m == "POST"]
+            assert posts == [
+                "https://pve01:8006/api2/json/nodes/pve01/qemu/200/snapshot/s1/rollback"
+            ]
+    finally:
+        await dbmod.dispose_engine()
+
+
+@pytest.mark.asyncio
+async def test_rollback_protected_vmid_refused(tmp_path, monkeypatch):
+    app, dbmod = await _boot(tmp_path, monkeypatch)
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeProxmox)
+    _FakeProxmox.calls = []
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            hid = await _create_host(c)
+            # 100 (pmg01) is canonically protected — rollback must refuse before any PVE call.
+            r = await c.post(
+                f"/v1/proxmox/hosts/{hid}/vms/100/snapshots/s1/rollback"
+            )
+            assert r.status_code == 409
+            assert r.json()["code"] == "VMID_PROTECTED"
+            assert [m for (m, *_) in _FakeProxmox.calls if m == "POST"] == []
+    finally:
+        await dbmod.dispose_engine()

--- a/tests/routes/test_proxmox_storage.py
+++ b/tests/routes/test_proxmox_storage.py
@@ -146,3 +146,56 @@ async def test_list_storage_content_invalid_type_422(tmp_path, monkeypatch):
             assert r.status_code == 422
     finally:
         await dbmod.dispose_engine()
+
+
+@pytest.mark.asyncio
+async def test_download_url_returns_upid(tmp_path, monkeypatch):
+    app, dbmod = await _boot(tmp_path, monkeypatch)
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeProxmox)
+    _FakeProxmox.calls = []
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            hid = await _create_host(c)
+            r = await c.post(
+                f"/v1/proxmox/hosts/{hid}/storage/local/download-url",
+                json={"content": "iso", "filename": "x.iso",
+                      "url": "https://h/x.iso"},
+            )
+            assert r.status_code == 200, r.text
+            assert r.json()["status"] == "accepted"
+            assert r.json()["upid"].startswith("UPID")
+            posts = [(u, d) for (m, u, d) in _FakeProxmox.calls if m == "POST"]
+            assert posts, "expected a POST to Proxmox"
+            url, data = posts[0]
+            assert url == ("https://pve01:8006/api2/json/nodes/pve01"
+                           "/storage/local/download-url")
+            assert data["content"] == "iso"
+            assert data["filename"] == "x.iso"
+            assert data["url"] == "https://h/x.iso"
+    finally:
+        await dbmod.dispose_engine()
+
+
+@pytest.mark.asyncio
+async def test_download_url_auth_failure_maps_502(tmp_path, monkeypatch):
+    app, dbmod = await _boot(tmp_path, monkeypatch)
+
+    class _AuthFailProxmox(_FakeProxmox):
+        async def post(self, url, headers=None, data=None):
+            _FakeProxmox.calls.append(("POST", url, data))
+            return _FakeResp(401, "invalid token")
+
+    monkeypatch.setattr(httpx, "AsyncClient", _AuthFailProxmox)
+    _FakeProxmox.calls = []
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            hid = await _create_host(c)
+            r = await c.post(
+                f"/v1/proxmox/hosts/{hid}/storage/local/download-url",
+                json={"content": "iso", "filename": "x.iso",
+                      "url": "https://h/x.iso"},
+            )
+            assert r.status_code == 502
+            assert r.json()["code"] == "AUTH_FAILED"
+    finally:
+        await dbmod.dispose_engine()

--- a/tests/routes/test_proxmox_storage.py
+++ b/tests/routes/test_proxmox_storage.py
@@ -1,0 +1,111 @@
+"""/v1/proxmox/hosts/{id}/storage — pools, content, download-url (direct PVE API)."""
+import json
+
+import httpx
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+async def _boot(tmp_path, monkeypatch):
+    db = tmp_path / "t.db"
+    monkeypatch.setenv("RANGE42_DB_URL", f"sqlite+aiosqlite:///{db}")
+    monkeypatch.setenv("RANGE42_WORKSPACE_ROOT", str(tmp_path))
+    from importlib import reload
+    from app.core import config as cfg
+    reload(cfg)
+    import app.core.db as dbmod
+    reload(dbmod)
+    from app.core.models import Base
+    engine = dbmod.get_engine()
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    from app.main import create_app
+    return create_app(), dbmod
+
+
+class _FakeResp:
+    def __init__(self, status_code, data):
+        self.status_code = status_code
+        self._data = data
+
+    def json(self):
+        return {"data": self._data}
+
+    @property
+    def text(self):
+        return json.dumps(self._data)
+
+
+class _FakeProxmox:
+    calls: list = []
+
+    def __init__(self, *a, **k):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def get(self, url, headers=None, params=None):
+        _FakeProxmox.calls.append(("GET", url, params))
+        if url.endswith("/storage"):
+            return _FakeResp(200, [
+                {"storage": "local", "type": "dir", "content": "iso,vztmpl",
+                 "total": 100, "used": 40, "avail": 60, "active": 1},
+                {"storage": "local-zfs", "type": "zfspool", "content": "images"},
+            ])
+        if url.endswith("/content"):
+            return _FakeResp(200, [
+                {"volid": "local:iso/ubuntu-22.04.iso", "content": "iso",
+                 "size": 1234, "format": "iso"},
+            ])
+        return _FakeResp(404, [])
+
+    async def post(self, url, headers=None, data=None):
+        _FakeProxmox.calls.append(("POST", url, data))
+        return _FakeResp(200, "UPID:pve01:0000:download::")
+
+
+async def _create_host(c):
+    r = await c.post("/v1/proxmox/hosts", json={
+        "name": "pve01", "api_url": "https://pve01:8006/", "node_name": "pve01",
+        "token_ref": "root@pam!tok=secret", "default_bridge": "vmbr0",
+    })
+    return r.json()["id"]
+
+
+@pytest.mark.asyncio
+async def test_list_storage_pools(tmp_path, monkeypatch):
+    app, dbmod = await _boot(tmp_path, monkeypatch)
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeProxmox)
+    _FakeProxmox.calls = []
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            hid = await _create_host(c)
+            r = await c.get(f"/v1/proxmox/hosts/{hid}/storage")
+            assert r.status_code == 200, r.text
+            body = r.json()
+            assert body["total"] == 2
+            assert body["items"][0] == {
+                "storage": "local", "type": "dir", "content": "iso,vztmpl",
+                "total": 100, "used": 40, "avail": 60, "active": True,
+            }
+            assert body["items"][1]["active"] is None
+            assert any(u == "https://pve01:8006/api2/json/nodes/pve01/storage"
+                       for (_, u, *_) in _FakeProxmox.calls)
+    finally:
+        await dbmod.dispose_engine()
+
+
+@pytest.mark.asyncio
+async def test_list_storage_unknown_host_404(tmp_path, monkeypatch):
+    app, dbmod = await _boot(tmp_path, monkeypatch)
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            r = await c.get("/v1/proxmox/hosts/nope/storage")
+            assert r.status_code == 404
+            assert r.json()["code"] == "NOT_FOUND"
+    finally:
+        await dbmod.dispose_engine()

--- a/tests/routes/test_proxmox_storage.py
+++ b/tests/routes/test_proxmox_storage.py
@@ -199,3 +199,47 @@ async def test_download_url_auth_failure_maps_502(tmp_path, monkeypatch):
             assert r.json()["code"] == "AUTH_FAILED"
     finally:
         await dbmod.dispose_engine()
+
+
+@pytest.mark.asyncio
+async def test_storage_content_rejects_bad_store(tmp_path, monkeypatch):
+    app, dbmod = await _boot(tmp_path, monkeypatch)
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            hid = await _create_host(c)
+            r = await c.get(f"/v1/proxmox/hosts/{hid}/storage/e!vil/content?content=iso")
+            assert r.status_code == 422
+    finally:
+        await dbmod.dispose_engine()
+
+
+@pytest.mark.asyncio
+async def test_download_url_rejects_non_http_scheme(tmp_path, monkeypatch):
+    app, dbmod = await _boot(tmp_path, monkeypatch)
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            hid = await _create_host(c)
+            r = await c.post(
+                f"/v1/proxmox/hosts/{hid}/storage/local/download-url",
+                json={"content": "iso", "filename": "x.iso",
+                      "url": "file:///etc/passwd"},
+            )
+            assert r.status_code == 422
+    finally:
+        await dbmod.dispose_engine()
+
+
+@pytest.mark.asyncio
+async def test_download_url_rejects_path_filename(tmp_path, monkeypatch):
+    app, dbmod = await _boot(tmp_path, monkeypatch)
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            hid = await _create_host(c)
+            r = await c.post(
+                f"/v1/proxmox/hosts/{hid}/storage/local/download-url",
+                json={"content": "iso", "filename": "../../etc/cron",
+                      "url": "https://h/x.iso"},
+            )
+            assert r.status_code == 422
+    finally:
+        await dbmod.dispose_engine()

--- a/tests/routes/test_proxmox_storage.py
+++ b/tests/routes/test_proxmox_storage.py
@@ -109,3 +109,40 @@ async def test_list_storage_unknown_host_404(tmp_path, monkeypatch):
             assert r.json()["code"] == "NOT_FOUND"
     finally:
         await dbmod.dispose_engine()
+
+
+@pytest.mark.asyncio
+async def test_list_storage_content_iso_derives_name(tmp_path, monkeypatch):
+    app, dbmod = await _boot(tmp_path, monkeypatch)
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeProxmox)
+    _FakeProxmox.calls = []
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            hid = await _create_host(c)
+            r = await c.get(
+                f"/v1/proxmox/hosts/{hid}/storage/local/content?content=iso"
+            )
+            assert r.status_code == 200, r.text
+            item = r.json()["items"][0]
+            assert item["name"] == "ubuntu-22.04.iso"
+            assert item["volid"] == "local:iso/ubuntu-22.04.iso"
+            assert item["size"] == 1234
+            # content type forwarded to PVE as a query param
+            assert any(p == {"content": "iso"} for (_, _u, p) in _FakeProxmox.calls
+                       if p is not None)
+    finally:
+        await dbmod.dispose_engine()
+
+
+@pytest.mark.asyncio
+async def test_list_storage_content_invalid_type_422(tmp_path, monkeypatch):
+    app, dbmod = await _boot(tmp_path, monkeypatch)
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            hid = await _create_host(c)
+            r = await c.get(
+                f"/v1/proxmox/hosts/{hid}/storage/local/content?content=bogus"
+            )
+            assert r.status_code == 422
+    finally:
+        await dbmod.dispose_engine()


### PR DESCRIPTION
## Summary

Adds v1 direct-httpx Proxmox endpoints for **storage** and **per-VM snapshots**, replacing the v0 Ansible-backed equivalents. Advances #87 (migrate remaining v0 admin/proxmox ops to v1). All endpoints address Proxmox by registered `host_id` (node derived from the host record — no `proxmox_node` param) and talk to the PVE REST API directly, mirroring the existing `vms.py`.

First commit extracts the shared host/PVE helpers (`_session`, `_get_host`, `_auth_headers`, `_assert_vmid_safe`, `_unreachable`, new `_raise_for_pve`) into `_helpers.py`, removing prior duplication between `vms.py` and `hosts.py`.

## Endpoints

Storage:
- `GET    /v1/proxmox/hosts/{host_id}/storage` → `Page[StoragePool]`
- `GET    /v1/proxmox/hosts/{host_id}/storage/{store}/content?content=iso|vztmpl` → `Page[StorageContent]` (derives `name` from `volid` — PVE doesn't return it)
- `POST   /v1/proxmox/hosts/{host_id}/storage/{store}/download-url` → `VmActionResult` (UPID)

Per-VM snapshots (qemu + lxc):
- `GET    /v1/proxmox/hosts/{host_id}/vms/{vmid}/snapshots` → `Page[SnapshotItem]` (filters PVE's synthetic `current`)
- `POST   /v1/proxmox/hosts/{host_id}/vms/{vmid}/snapshots` → `VmActionResult` (UPID)
- `DELETE /v1/proxmox/hosts/{host_id}/vms/{vmid}/snapshots/{name}` → `VmActionResult` (UPID)
- `POST   /v1/proxmox/hosts/{host_id}/vms/{vmid}/snapshots/{name}/rollback` → `VmActionResult` (UPID) — **vmid-guarded** (protected VMIDs refused before any outbound call)

## Security hardening

A review pass added input validation: `Path(pattern=...)` constraints on `{store}` and `{name}` (block path-segment injection into outbound URLs), an http(s)-only scheme guard on `download-url` `url` (SSRF), and a bare-filename guard on `filename` (file-plant).

## Notes

- `httpx.AsyncClient(verify=False)` matches existing `vms.py`/`hosts.py`; TLS pinning tracked separately in #85 (out of scope here).
- Snapshot `vmtype=lxc` and the `vmstate` flag are net-new vs v0 (v0 was qemu-only).

## Tests

- 33/33 proxmox route suite green (`tests/routes/test_proxmox_{storage,snapshots,vms,hosts}.py`), house pattern (`_boot` temp-sqlite + faked `httpx.AsyncClient`).
- Two repo-wide failures (`test_alembic`, `test_expand_replication`) are pre-existing — reproduced at the base commit and untouched by this diff (which is confined to 9 proxmox files).

## Follow-up (separate PR)

deployer-ui: repoint `storage.*` / `snapshot.*` in `src/services/proxmox/api.ts` at these v1 paths (`.items`-unwrap the `Page`), drop `proxmox_node` args.
