### PR TITLE
fix(deploy): container config contract — compose .env, in-container SSH unlock, Git PAT hardening

### DIFF
--- a/app/core/deploy_trigger.py
+++ b/app/core/deploy_trigger.py
@@ -102,16 +102,6 @@ async def start_attempt(session: AsyncSession, *, attempt: Attempt,
     if vault_pass.exists():
         envvars["ANSIBLE_VAULT_PASSWORD_FILE"] = str(vault_pass)
 
-    # Unlock the workspace's passphrase-protected SSH keys into a dedicated
-    # ssh-agent (there is none in the container) so ansible-runner can reach the
-    # Proxmox jump + VMs. Returns None when there is no vault/keys, in which case
-    # the deploy falls back to the ambient ~/.ssh. Closed in _run()'s finally.
-    ssh_agent = None
-    if vault_pass.exists():
-        ssh_agent = unlock_workspace_keys(ws, vault_pass)
-        if ssh_agent is not None:
-            envvars.update(ssh_agent.env)
-
     extravars: dict[str, Any] = {
         "r42_deployment_id": dep.id,
         "r42_attempt_id": attempt.id,
@@ -198,12 +188,33 @@ async def start_attempt(session: AsyncSession, *, attempt: Attempt,
         # <ws>/inventory/; do not clone or generate anything.
         extravars["r42_inventory_dir"] = str(ws / "inventory")
 
+    # Unlock the workspace's passphrase-protected SSH keys into a dedicated
+    # ssh-agent (there is none in the container) so ansible-runner can reach the
+    # Proxmox jump + VMs. Returns None when there is no vault/keys, in which case
+    # the deploy falls back to the ambient ~/.ssh.
+    #
+    # Deliberately last: everything above can raise (missing project_sha, git
+    # checkout failure, malformed topology, absent Project/Source/ProxmoxHost),
+    # and an agent started before those would outlive the failed attempt holding
+    # unlocked private keys with nothing to reap it. The only remaining window
+    # is runner.start() itself, closed below; after that _run()'s finally owns it.
+    ssh_agent = None
+    if vault_pass.exists():
+        ssh_agent = unlock_workspace_keys(ws, vault_pass)
+        if ssh_agent is not None:
+            envvars.update(ssh_agent.env)
+
     runner = runner or DetachedRunner()
-    handle = await runner.start(
-        private_data_dir=artifact_dir,
-        extravars=extravars,
-        envvars=envvars,
-    )
+    try:
+        handle = await runner.start(
+            private_data_dir=artifact_dir,
+            extravars=extravars,
+            envvars=envvars,
+        )
+    except BaseException:
+        if ssh_agent is not None:
+            ssh_agent.close()
+        raise
     (artifact_dir / "pid").write_text(str(handle.pid or 0))
 
     layers = [ConfigDenylistLayer(settings.redaction_denylist),

--- a/app/core/deploy_trigger.py
+++ b/app/core/deploy_trigger.py
@@ -35,6 +35,7 @@ from app.core.redaction import (
 )
 from app.core.runner_detached import DetachedRunner
 from app.core.runner_protocol import RunnerProtocol
+from app.core.ssh_agent import unlock_workspace_keys
 from app.core.workspace import shred_envvars
 from app.utils.checks_playbooks import resolve_scenarios_playbook
 
@@ -100,6 +101,16 @@ async def start_attempt(session: AsyncSession, *, attempt: Attempt,
     vault_pass = ws / "secrets" / "vault_pass.txt"
     if vault_pass.exists():
         envvars["ANSIBLE_VAULT_PASSWORD_FILE"] = str(vault_pass)
+
+    # Unlock the workspace's passphrase-protected SSH keys into a dedicated
+    # ssh-agent (there is none in the container) so ansible-runner can reach the
+    # Proxmox jump + VMs. Returns None when there is no vault/keys, in which case
+    # the deploy falls back to the ambient ~/.ssh. Closed in _run()'s finally.
+    ssh_agent = None
+    if vault_pass.exists():
+        ssh_agent = unlock_workspace_keys(ws, vault_pass)
+        if ssh_agent is not None:
+            envvars.update(ssh_agent.env)
 
     extravars: dict[str, Any] = {
         "r42_deployment_id": dep.id,
@@ -217,6 +228,10 @@ async def start_attempt(session: AsyncSession, *, attempt: Attempt,
                           attempt_id=attempt.id, deployment_id=dep.id)
             logger.info("attempt finished", attempt_id=attempt.id, rc=rc)
         finally:
+            # Kill the ssh-agent started for this attempt (if any) so it does
+            # not outlive the deploy.
+            if ssh_agent is not None:
+                ssh_agent.close()
             # Shred secrets-bearing files in the runner's private_data_dir.
             # Defense-in-depth: prevents the snapshotted PAT / vault pass from
             # sitting on disk after the attempt completes. Runs on both success

--- a/app/core/project.py
+++ b/app/core/project.py
@@ -20,6 +20,17 @@ def _redact_authed_url(s: str) -> str:
     return _AUTHED_URL_RE.sub('https://[REDACTED]@', s)
 
 
+def authed_url(url: str, token: str | None) -> str:
+    """Embed a Git PAT into an https clone URL as x-access-token.
+
+    Returns the URL unchanged when there is no token or it is not an https URL.
+    Callers MUST redact any error containing the result via ``_redact_authed_url``.
+    """
+    if token and url.startswith("https://"):
+        return url.replace("https://", f"https://x-access-token:{token}@", 1)
+    return url
+
+
 def _run_git(*args: str, cwd: Path | None = None) -> subprocess.CompletedProcess:
     """Run a git command, raising ProjectCheckoutError with redacted stderr on failure."""
     try:
@@ -72,9 +83,7 @@ def checkout_project(
         return dest / "topology.json"
 
     # Build URL with token if present (stripped from logs by existing redaction)
-    url = repo_url
-    if token and url.startswith("https://"):
-        url = url.replace("https://", f"https://x-access-token:{token}@", 1)
+    url = authed_url(repo_url, token)
 
     if dest.exists() and (dest / ".git").exists():
         # Existing repo, fetch the SHA and reset
@@ -86,10 +95,11 @@ def checkout_project(
             import shutil
             shutil.rmtree(dest)
         dest.parent.mkdir(parents=True, exist_ok=True)
-        # Initial clone — fetch a single SHA depth-1
+        # Initial clone — fetch a single SHA depth-1. Fetch the URL ad-hoc
+        # rather than `git remote add origin <url>`: a named remote would
+        # persist the authed URL (Git PAT) in .git/config on the workspace disk.
         _run_git("init", "-q", str(dest))
-        _run_git("remote", "add", "origin", url, cwd=dest)
-        _run_git("fetch", "--depth", "1", "origin", sha, cwd=dest)
+        _run_git("fetch", "--depth", "1", url, sha, cwd=dest)
         _run_git("checkout", "FETCH_HEAD", cwd=dest)
 
     topology = dest / "topology.json"

--- a/app/core/ssh_agent.py
+++ b/app/core/ssh_agent.py
@@ -1,0 +1,180 @@
+"""In-container unlock of passphrase-protected range42 SSH keys.
+
+The range42 deploy keys are ed25519 keys protected by a per-family passphrase
+stored in the workspace vault (``secrets/default_vault.yml``, keys
+``ssh_passphrase_*``). On the deployer host ``range42-context`` loads them into
+an ssh-agent via an SSH_ASKPASS shim; inside the backend container there is no
+such agent, so ansible-runner cannot authenticate to the VMs.
+
+``unlock_workspace_keys`` reproduces that mechanism: decrypt the vault with the
+workspace ``vault_pass.txt``, start a dedicated ssh-agent, and ``ssh-add`` every
+private key found under ``ssh_keys/`` using its passphrase (via a throwaway
+SSH_ASKPASS script). The returned handle exposes ``SSH_AUTH_SOCK`` to merge into
+the runner's envvars and a ``close()`` to kill the agent when the attempt ends.
+"""
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+# Map a private-key filename suffix to the vault field holding its passphrase.
+# Order matters: the extra-student glob (``_bob_<n>``) must be checked before
+# the plain ``_bob`` suffix. Mirrors range42-context._r42_passphrase_field_for_key.
+_SUFFIX_TO_FIELD: tuple[tuple[str, str], ...] = (
+    ("ssh_cli.root", "ssh_passphrase_px_root"),
+    ("ssh_cli.jump_user", "ssh_passphrase_px_jump"),
+    ("deployer-key_alice", "ssh_passphrase_deployer_admin"),
+    ("student-key_bob", "ssh_passphrase_student_user"),
+)
+
+# Filenames under ssh_keys/ that are never private keys.
+_NON_KEY_NAMES = {"known_hosts", "config", "authorized_keys"}
+
+
+@dataclass
+class SshAgentHandle:
+    """A running ssh-agent with the workspace keys loaded."""
+
+    pid: int
+    env: dict[str, str] = field(default_factory=dict)
+    _closed: bool = False
+
+    def close(self) -> None:
+        """Kill the agent process. Idempotent."""
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            subprocess.run(
+                ["ssh-agent", "-k"],
+                env={**self.env, "SSH_AGENT_PID": str(self.pid)},
+                capture_output=True, text=True, check=False,
+            )
+        except OSError:
+            pass
+        try:
+            os.kill(self.pid, 0)
+            os.kill(self.pid, 15)
+        except OSError:
+            pass
+
+
+def _passphrase_field_for(name: str) -> str | None:
+    if "student-key_bob_" in name:
+        return "ssh_passphrase_student_user_extra_all"
+    for suffix, field_name in _SUFFIX_TO_FIELD:
+        if name.endswith(suffix):
+            return field_name
+    return None
+
+
+def _discover_private_keys(ssh_keys_dir: Path) -> list[Path]:
+    if not ssh_keys_dir.is_dir():
+        return []
+    keys: list[Path] = []
+    for p in sorted(ssh_keys_dir.rglob("*")):
+        if not p.is_file():
+            continue
+        if p.name.endswith(".pub") or p.name in _NON_KEY_NAMES:
+            continue
+        keys.append(p)
+    return keys
+
+
+def _decrypt_vault(vault_file: Path, vault_password_file: Path) -> dict:
+    r = subprocess.run(
+        ["ansible-vault", "view", "--vault-password-file",
+         str(vault_password_file), str(vault_file)],
+        capture_output=True, text=True, check=True,
+    )
+    data = yaml.safe_load(r.stdout)
+    return data if isinstance(data, dict) else {}
+
+
+def _start_agent() -> SshAgentHandle:
+    r = subprocess.run(["ssh-agent", "-s"], capture_output=True, text=True,
+                       check=True)
+    sock = ""
+    pid = 0
+    for line in r.stdout.splitlines():
+        line = line.strip()
+        if line.startswith("SSH_AUTH_SOCK="):
+            sock = line[len("SSH_AUTH_SOCK="):].split(";", 1)[0]
+        elif line.startswith("SSH_AGENT_PID="):
+            pid = int(line[len("SSH_AGENT_PID="):].split(";", 1)[0])
+    return SshAgentHandle(pid=pid, env={"SSH_AUTH_SOCK": sock})
+
+
+def _ssh_add(key: Path, passphrase: str, agent_env: dict[str, str]) -> bool:
+    """ssh-add one key, feeding the passphrase non-interactively via SSH_ASKPASS.
+
+    A passphrase-less key ignores the askpass shim and still loads.
+    """
+    fd, askpass_path = tempfile.mkstemp(prefix="r42-askpass-", suffix=".sh")
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write('#!/bin/sh\nprintf "%s" "$SSH_ASKPASS_PASSWORD"\n')
+        os.chmod(askpass_path, stat.S_IRWXU)
+        env = {
+            **agent_env,
+            "SSH_ASKPASS": askpass_path,
+            "SSH_ASKPASS_PASSWORD": passphrase,
+            "SSH_ASKPASS_REQUIRE": "force",
+            "DISPLAY": os.environ.get("DISPLAY", ":0"),
+        }
+        r = subprocess.run(["ssh-add", str(key)], env=env,
+                           stdin=subprocess.DEVNULL,
+                           capture_output=True, text=True)
+        return r.returncode == 0
+    finally:
+        try:
+            os.unlink(askpass_path)
+        except OSError:
+            pass
+
+
+def unlock_workspace_keys(
+    workspace: Path, vault_password_file: Path
+) -> SshAgentHandle | None:
+    """Start an ssh-agent and load the workspace's private keys into it.
+
+    :returns: A handle exposing ``SSH_AUTH_SOCK`` in ``.env``, or ``None`` when
+        there is no vault or no keys to unlock (the deploy then falls back to the
+        ambient ~/.ssh, preserving prior behaviour).
+    """
+    workspace = Path(workspace)
+    vault_file = workspace / "secrets" / "default_vault.yml"
+    if not vault_file.is_file():
+        return None
+    keys = _discover_private_keys(workspace / "ssh_keys")
+    if not keys:
+        return None
+
+    try:
+        passphrases = _decrypt_vault(vault_file, Path(vault_password_file))
+    except (subprocess.CalledProcessError, OSError) as exc:
+        logger.warning("ssh_agent vault decrypt failed", error=str(exc))
+        return None
+
+    handle = _start_agent()
+    loaded = 0
+    for key in keys:
+        field_name = _passphrase_field_for(key.name)
+        passphrase = str(passphrases.get(field_name, "")) if field_name else ""
+        if _ssh_add(key, passphrase, handle.env):
+            loaded += 1
+        else:
+            logger.warning("ssh_agent could not add key", key=key.name)
+    logger.info("ssh_agent unlocked workspace keys", loaded=loaded,
+                total=len(keys))
+    return handle

--- a/app/routes/v1/catalog/entries.py
+++ b/app/routes/v1/catalog/entries.py
@@ -26,6 +26,7 @@ import git  # type: ignore
 
 from app.core.db import get_session_factory
 from app.core.errors import Range42Error, SourceUnreachableError
+from app.core.project import _redact_authed_url, authed_url
 from app.core.models import Source, SourceRepo
 from app.schemas.v1.catalog import CatalogEntryDetail, CatalogEntrySummary
 from app.schemas.v1.common import Page
@@ -41,7 +42,10 @@ async def _session() -> AsyncSession:
 
 
 def _clone_repo(src: Source, repo: SourceRepo, workdir: Path) -> Path:
-    url = f"{str(src.base_url).rstrip('/')}/{repo.owner}/{repo.repo}.git"
+    url = authed_url(
+        f"{str(src.base_url).rstrip('/')}/{repo.owner}/{repo.repo}.git",
+        src.token_ref,
+    )
     dest = workdir / f"{src.id}-{repo.owner}-{repo.repo}"
     if not dest.exists():
         try:
@@ -51,7 +55,8 @@ def _clone_repo(src: Source, repo: SourceRepo, workdir: Path) -> Path:
                 details=[
                     {
                         "field": "source_id",
-                        "reason": f"{repo.owner}/{repo.repo}: {e}",
+                        "reason": _redact_authed_url(
+                            f"{repo.owner}/{repo.repo}: {e}"),
                     }
                 ]
             )

--- a/app/routes/v1/catalog/refresh.py
+++ b/app/routes/v1/catalog/refresh.py
@@ -75,9 +75,21 @@ def _count_entries_in_repo(src: Source, repo: SourceRepo) -> int:
 
     import git  # type: ignore
 
-    url = f"{str(src.base_url).rstrip('/')}/{repo.owner}/{repo.repo}.git"
+    from app.core.project import _redact_authed_url, authed_url
+
+    url = authed_url(
+        f"{str(src.base_url).rstrip('/')}/{repo.owner}/{repo.repo}.git",
+        src.token_ref,
+    )
     with tempfile.TemporaryDirectory() as td:
-        git.Repo.clone_from(url, td, depth=1, branch=repo.branch)
+        try:
+            git.Repo.clone_from(url, td, depth=1, branch=repo.branch)
+        except Exception as e:
+            raise SourceUnreachableError(
+                details=[{"field": "source_id",
+                          "reason": _redact_authed_url(
+                              f"{repo.owner}/{repo.repo}: {e}")}]
+            )
         root = Path(td)
         count = 0
         for _p in root.rglob("range42.yaml"):

--- a/app/routes/v1/catalog/sources.py
+++ b/app/routes/v1/catalog/sources.py
@@ -22,6 +22,18 @@ async def _session() -> AsyncSession:
         yield session
 
 
+def _to_out(row: Source) -> SourceOut:
+    """Serialise a Source without ever exposing the raw token; has_token only."""
+    return SourceOut(
+        id=row.id,
+        provider=row.provider,
+        base_url=row.base_url,
+        auth_kind=row.auth_kind,
+        has_token=bool(row.token_ref),
+        created_at=row.created_at,
+    )
+
+
 @router.get("/sources", response_model=Page[SourceOut])
 async def list_sources(
     session: AsyncSession = Depends(_session),
@@ -32,7 +44,7 @@ async def list_sources(
     rows = (
         await session.execute(select(Source).offset(offset).limit(limit))
     ).scalars().all()
-    items = [SourceOut.model_validate(r, from_attributes=True) for r in rows]
+    items = [_to_out(r) for r in rows]
     return Page[SourceOut](items=items, total=total, offset=offset, limit=limit)
 
 
@@ -50,7 +62,7 @@ async def create_source(
     session.add(row)
     await session.commit()
     await session.refresh(row)
-    return SourceOut.model_validate(row, from_attributes=True)
+    return _to_out(row)
 
 
 @router.delete("/sources/{source_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/app/schemas/v1/catalog.py
+++ b/app/schemas/v1/catalog.py
@@ -18,7 +18,8 @@ class SourceOut(BaseModel):
     provider: str
     base_url: HttpUrl
     auth_kind: str
-    token_ref: str | None = None
+    # The PAT itself is never returned; expose only whether one is stored.
+    has_token: bool = False
     created_at: datetime
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,11 +16,22 @@ services:
       # Inventory contains per-deployment host credentials. Uncomment to
       # override the baked-in inventory without rebuilding the image:
       # - ${INVENTORY_PATH:-./inventory}:/app/inventory:ro
+    # A deploy bundle renders a .env in the compose project dir; load it as the
+    # runtime source of truth. required:false keeps plain `docker compose up`
+    # working with no .env. Only vars actually present in .env are set — so
+    # unset RANGE42_* fall back to the app defaults instead of being forced to
+    # an empty string (which the app would treat as a real, broken value).
+    env_file:
+      - path: .env
+        required: false
     environment:
       - PROJECT_ROOT_DIR=/app
-      - API_BACKEND_WWWAPP_PLAYBOOKS_DIR=/app/
+      # Overridable via .env so a deploy bundle can point the backend at a
+      # bind-mounted playbooks tree (e.g. /home/range42/range42-playbooks).
+      # The baked-in /app/ has no scenarios/, so real deploys MUST override this.
+      - API_BACKEND_WWWAPP_PLAYBOOKS_DIR=${API_BACKEND_WWWAPP_PLAYBOOKS_DIR:-/app/}
       - API_BACKEND_PUBLIC_PLAYBOOKS_DIR=${API_BACKEND_PUBLIC_PLAYBOOKS_DIR:-/app/}
-      - API_BACKEND_INVENTORY_DIR=/app/inventory/
+      - API_BACKEND_INVENTORY_DIR=${API_BACKEND_INVENTORY_DIR:-/app/inventory/}
       - API_BACKEND_VAULT_FILE=${API_BACKEND_VAULT_FILE:-}
       # Production: use VAULT_PASSWORD_FILE pointing to a mounted secret file.
       # VAULT_PASSWORD is visible via `docker inspect` — dev/testing only.

--- a/openapi.json
+++ b/openapi.json
@@ -8659,16 +8659,10 @@
             "type": "string",
             "title": "Auth Kind"
           },
-          "token_ref": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Token Ref"
+          "has_token": {
+            "type": "boolean",
+            "title": "Has Token",
+            "default": false
           },
           "created_at": {
             "type": "string",

--- a/tests/core/test_deploy_trigger.py
+++ b/tests/core/test_deploy_trigger.py
@@ -645,3 +645,143 @@ async def test_start_attempt_universal_requires_repo_owner_and_name(
         with pytest.raises(ProjectCheckoutError) as exc:
             await start_attempt(s, attempt=att, runner=_NoOpRunner())
         assert "repo_owner" in str(exc.value.message) or "repo_name" in str(exc.value.message)
+
+
+# ---------------------------------------------------------------------------
+# ssh-agent lifetime: an agent holding unlocked private keys must never
+# outlive the attempt that started it.
+# ---------------------------------------------------------------------------
+
+
+class _FakeAgent:
+    """Stand-in for SshAgentHandle that records close()."""
+
+    def __init__(self) -> None:
+        self.env = {"SSH_AUTH_SOCK": "/tmp/fake.sock"}
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+async def _seed_deploy(tmp_path, monkeypatch, *, scenario, dep_id, att_id,
+                       with_sha=True):
+    """Minimal DB + workspace fixture; returns the workspace path."""
+    monkeypatch.setenv("RANGE42_DB_URL", f"sqlite+aiosqlite:///{tmp_path / 't.db'}")
+    monkeypatch.setenv("RANGE42_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("RANGE42_AUTO_START_ATTEMPTS", "0")
+
+    pb_root = tmp_path / "playbooks"
+    (pb_root / "scenarios" / scenario).mkdir(parents=True, exist_ok=True)
+    (pb_root / "scenarios" / scenario / "main.yml").write_text(
+        "- hosts: all\n  tasks: []\n")
+    monkeypatch.setenv("API_BACKEND_WWWAPP_PLAYBOOKS_DIR", str(pb_root))
+
+    from importlib import reload
+    from app.core import config as cfg, db as dbmod
+    reload(cfg)
+    reload(dbmod)
+    from app.core.models import (
+        Base, Source, ProxmoxHost, Project, Deployment, Attempt,
+    )
+    engine = dbmod.get_engine()
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    ws = tmp_path / f"WS-{scenario}"
+    for sub in ("runner", "secrets", "ssh_keys", "inventory"):
+        (ws / sub).mkdir(parents=True, exist_ok=True)
+    # vault_pass.txt present => start_attempt takes the unlock branch
+    (ws / "secrets" / "vault_pass.txt").write_text("vaultpw")
+
+    async with dbmod.get_session_factory()() as s:
+        s.add(Source(id="s", provider="github", base_url="u", auth_kind="none"))
+        s.add(ProxmoxHost(id="h", name="n", api_url="u", node_name="n",
+                          token_ref="t"))
+        await s.commit()
+    async with dbmod.get_session_factory()() as s:
+        s.add(Project(id="p", name="p", source_id="s",
+                      branch_strategy="shared_repo_subdir",
+                      repo_owner="me", repo_name="proj"))
+        await s.commit()
+    async with dbmod.get_session_factory()() as s:
+        s.add(Deployment(
+            id=dep_id, codename="WS", scenario_label=scenario, project_id="p",
+            target_host_id="h", team_count=1, state="pending",
+            workspace_path=str(ws),
+            **({"project_sha": "deadbeef"} if with_sha else {}),
+        ))
+        await s.commit()
+    async with dbmod.get_session_factory()() as s:
+        s.add(Attempt(id=att_id, deployment_id=dep_id, scope="full",
+                      state="pending"))
+        await s.commit()
+    return dbmod
+
+
+@pytest.mark.asyncio
+async def test_start_attempt_does_not_unlock_keys_before_it_can_fail(
+    tmp_path, monkeypatch,
+):
+    """The unlock must happen after every raise site.
+
+    An agent started earlier would survive a failed attempt holding unlocked
+    private keys, with nothing to reap it — and a bad project_sha is an
+    ordinary user error, so failures repeat.
+    """
+    dbmod = await _seed_deploy(tmp_path, monkeypatch, scenario="_universal",
+                               dep_id="dep-leak", att_id="att-leak",
+                               with_sha=False)
+
+    called = []
+    monkeypatch.setattr(
+        "app.core.deploy_trigger.unlock_workspace_keys",
+        lambda ws, vp: called.append(ws) or _FakeAgent(),
+    )
+
+    class _NoOpRunner:
+        async def start(self, *, private_data_dir, extravars, envvars):
+            raise AssertionError("should not reach the runner")
+
+    from app.core.deploy_trigger import start_attempt
+    from app.core.errors import ProjectCheckoutError
+    from app.core.models import Attempt
+    from sqlalchemy import select
+
+    async with dbmod.get_session_factory()() as s:
+        att = (await s.execute(
+            select(Attempt).where(Attempt.id == "att-leak"))).scalar_one()
+        with pytest.raises(ProjectCheckoutError):
+            await start_attempt(s, attempt=att, runner=_NoOpRunner())
+
+    assert called == [], "ssh-agent was started before the attempt could fail"
+
+
+@pytest.mark.asyncio
+async def test_start_attempt_closes_ssh_agent_when_runner_start_fails(
+    tmp_path, monkeypatch,
+):
+    """runner.start() is the last window; a failure there must kill the agent."""
+    dbmod = await _seed_deploy(tmp_path, monkeypatch, scenario="demo_lab",
+                               dep_id="dep-rs", att_id="att-rs")
+
+    agent = _FakeAgent()
+    monkeypatch.setattr("app.core.deploy_trigger.unlock_workspace_keys",
+                        lambda ws, vp: agent)
+
+    class _BoomRunner:
+        async def start(self, *, private_data_dir, extravars, envvars):
+            assert envvars["SSH_AUTH_SOCK"] == "/tmp/fake.sock"
+            raise RuntimeError("runner exploded")
+
+    from app.core.deploy_trigger import start_attempt
+    from app.core.models import Attempt
+    from sqlalchemy import select
+
+    async with dbmod.get_session_factory()() as s:
+        att = (await s.execute(
+            select(Attempt).where(Attempt.id == "att-rs"))).scalar_one()
+        with pytest.raises(RuntimeError):
+            await start_attempt(s, attempt=att, runner=_BoomRunner())
+
+    assert agent.closed, "ssh-agent leaked when runner.start() failed"

--- a/tests/core/test_deploy_trigger.py
+++ b/tests/core/test_deploy_trigger.py
@@ -134,6 +134,101 @@ async def test_start_attempt_passes_playbook_path_in_extravars(tmp_path, monkeyp
     assert captured["extravars"]["r42_attempt_id"] == "att-x"
 
 
+@pytest.mark.asyncio
+async def test_start_attempt_injects_ssh_auth_sock_when_workspace_has_vault_keys(
+    tmp_path, monkeypatch,
+):
+    """When the workspace ships a vault + passphrase-protected keys, start_attempt
+    unlocks them into an ssh-agent and forwards SSH_AUTH_SOCK to the runner env,
+    so ansible-runner can authenticate to the VMs from inside the container."""
+    import subprocess as sp
+
+    import yaml as _yaml
+
+    monkeypatch.setenv("RANGE42_DB_URL", f"sqlite+aiosqlite:///{tmp_path / 't.db'}")
+    monkeypatch.setenv("RANGE42_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("RANGE42_AUTO_START_ATTEMPTS", "0")
+
+    pb_root = tmp_path / "playbooks"
+    (pb_root / "scenarios" / "demo_lab").mkdir(parents=True)
+    (pb_root / "scenarios" / "demo_lab" / "main.yml").write_text(
+        "- hosts: all\n  tasks: []\n")
+    monkeypatch.setenv("API_BACKEND_WWWAPP_PLAYBOOKS_DIR", str(pb_root))
+
+    from importlib import reload
+    from app.core import config as cfg, db as dbmod
+    reload(cfg)
+    reload(dbmod)
+    from app.core.models import (
+        Base, Source, ProxmoxHost, Project, Deployment, Attempt,
+    )
+    engine = dbmod.get_engine()
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    ws = tmp_path / "WS-demo_lab"
+    (ws / "runner").mkdir(parents=True)
+    (ws / "secrets").mkdir()
+    key_dir = ws / "ssh_keys" / "backend_keys"
+    key_dir.mkdir(parents=True)
+    vp = ws / "secrets" / "vault_pass.txt"
+    vp.write_text("vaultpw")
+    sp.run(["ssh-keygen", "-t", "ed25519", "-N", "kp", "-C", "k", "-f",
+            str(key_dir / "r42.WS-demo_lab-deployer-key_alice")],
+           check=True, capture_output=True, text=True)
+    vfile = ws / "secrets" / "default_vault.yml"
+    vfile.write_text(_yaml.safe_dump({"ssh_passphrase_deployer_admin": "kp"}))
+    sp.run(["ansible-vault", "encrypt", "--vault-password-file", str(vp),
+            str(vfile)], check=True, capture_output=True, text=True)
+
+    async with dbmod.get_session_factory()() as s:
+        s.add(Source(id="s", provider="github", base_url="u", auth_kind="none"))
+        s.add(ProxmoxHost(id="h", name="n", api_url="u", node_name="n", token_ref="t"))
+        await s.commit()
+    async with dbmod.get_session_factory()() as s:
+        s.add(Project(id="p", name="p", source_id="s",
+                      branch_strategy="shared_repo_subdir"))
+        await s.commit()
+    async with dbmod.get_session_factory()() as s:
+        s.add(Deployment(id="dep-k", codename="WS", scenario_label="demo_lab",
+                         project_id="p", target_host_id="h", team_count=1,
+                         state="pending", workspace_path=str(ws)))
+        await s.commit()
+    async with dbmod.get_session_factory()() as s:
+        s.add(Attempt(id="att-k", deployment_id="dep-k", scope="full",
+                      state="pending"))
+        await s.commit()
+
+    captured: dict = {}
+
+    class _CaptureHandle:
+        pid = 4242
+        async def wait(self) -> int:
+            return 0
+        async def kill(self) -> None:
+            pass
+
+    class _CaptureRunner:
+        async def start(self, *, private_data_dir, extravars, envvars):
+            captured["envvars"] = dict(envvars)
+            private_data_dir.mkdir(parents=True, exist_ok=True)
+            return _CaptureHandle()
+
+    from app.core.deploy_trigger import start_attempt
+    from sqlalchemy import select
+
+    async with dbmod.get_session_factory()() as s:
+        att = (await s.execute(
+            select(Attempt).where(Attempt.id == "att-k"))).scalar_one()
+        await start_attempt(s, attempt=att, runner=_CaptureRunner())
+
+    import asyncio
+    await asyncio.sleep(0.1)  # let the background _run() close the agent
+
+    assert "SSH_AUTH_SOCK" in captured["envvars"]
+    assert captured["envvars"]["SSH_AUTH_SOCK"]
+
+
 # ---------------------------------------------------------------------------
 # T8: Universal scenario path — project checkout + inventory generation
 # ---------------------------------------------------------------------------

--- a/tests/core/test_project.py
+++ b/tests/core/test_project.py
@@ -46,6 +46,25 @@ def test_checkout_project_idempotent_same_sha(tmp_path):
     assert mtime1 == mtime2, "Re-checkout at same SHA should be idempotent"
 
 
+def test_checkout_project_does_not_persist_remote_credentials(tmp_path):
+    """The clone must not leave a named remote in .git/config: for an https repo
+    that would embed the Git PAT (x-access-token) on disk in the persistent
+    workspace. We fetch the URL ad-hoc instead of `git remote add origin`."""
+    src = tmp_path / "src"
+    sha = _make_test_repo(src)
+    dst = tmp_path / "ws" / "project"
+
+    checkout_project(repo_url=f"file://{src}", sha=sha, dest=dst, token="ghp_SECRET")
+
+    cfg = (dst / ".git" / "config").read_text()
+    assert "ghp_SECRET" not in cfg
+    r = subprocess.run(
+        ["git", "config", "--get", "remote.origin.url"],
+        cwd=dst, capture_output=True, text=True,
+    )
+    assert r.returncode != 0, "no origin remote should be persisted after checkout"
+
+
 def test_checkout_project_fails_typed(tmp_path):
     dst = tmp_path / "ws" / "project"
     with pytest.raises(ProjectCheckoutError) as exc:

--- a/tests/core/test_project_authed_url.py
+++ b/tests/core/test_project_authed_url.py
@@ -1,0 +1,27 @@
+"""Unit tests for the shared authed_url helper used to embed a Git PAT into an
+https clone URL (project + catalog clones reuse it)."""
+from app.core.project import authed_url
+
+
+def test_embeds_token_as_x_access_token():
+    assert authed_url("https://github.com/o/r.git", "ghp_SECRET") == (
+        "https://x-access-token:ghp_SECRET@github.com/o/r.git"
+    )
+
+
+def test_none_token_leaves_url_unchanged():
+    assert authed_url("https://github.com/o/r.git", None) == (
+        "https://github.com/o/r.git"
+    )
+
+
+def test_empty_token_leaves_url_unchanged():
+    assert authed_url("https://github.com/o/r.git", "") == (
+        "https://github.com/o/r.git"
+    )
+
+
+def test_non_https_url_is_untouched():
+    assert authed_url("git@github.com:o/r.git", "ghp_SECRET") == (
+        "git@github.com:o/r.git"
+    )

--- a/tests/core/test_ssh_agent.py
+++ b/tests/core/test_ssh_agent.py
@@ -1,0 +1,146 @@
+"""Tests for app.core.ssh_agent — in-container unlock of passphrase-protected
+range42 SSH keys from the workspace vault, mirroring range42-context's
+SSH_ASKPASS mechanism so the backend's ansible-runner can reach the VMs.
+"""
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+from app.core.ssh_agent import unlock_workspace_keys
+
+
+def _gen_key(path: Path, passphrase: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["ssh-keygen", "-t", "ed25519", "-N", passphrase, "-C", path.name,
+         "-f", str(path)],
+        check=True, capture_output=True, text=True,
+    )
+
+
+def _make_vault(path: Path, body: dict, vault_pass_file: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(body, sort_keys=True))
+    subprocess.run(
+        ["ansible-vault", "encrypt", "--vault-password-file",
+         str(vault_pass_file), str(path)],
+        check=True, capture_output=True, text=True,
+    )
+
+
+def _agent_key_count(sock: str) -> int:
+    r = subprocess.run(["ssh-add", "-l"], env={"SSH_AUTH_SOCK": sock},
+                       capture_output=True, text=True)
+    if r.returncode != 0:
+        return 0
+    return len([ln for ln in r.stdout.splitlines() if ln.strip()])
+
+
+def test_unlock_loads_passphrase_protected_key(tmp_path):
+    ws = tmp_path / "ALPHA-demo"
+    vault_pass = ws / "secrets" / "vault_pass.txt"
+    vault_pass.parent.mkdir(parents=True)
+    vault_pass.write_text("vaultpw")
+
+    passphrase = "s3cret-key-pass"
+    _gen_key(ws / "ssh_keys" / "backend_keys"
+             / "r42.ALPHA-demo-deployer-key_alice", passphrase)
+    _make_vault(ws / "secrets" / "default_vault.yml",
+                {"ssh_passphrase_deployer_admin": passphrase},
+                vault_pass)
+
+    handle = unlock_workspace_keys(ws, vault_pass)
+    try:
+        assert handle is not None
+        assert "SSH_AUTH_SOCK" in handle.env
+        assert _agent_key_count(handle.env["SSH_AUTH_SOCK"]) == 1
+    finally:
+        if handle is not None:
+            handle.close()
+
+
+def test_returns_none_when_no_vault(tmp_path):
+    ws = tmp_path / "A-b"
+    _gen_key(ws / "ssh_keys" / "backend_keys"
+             / "r42.A-b-deployer-key_alice", "pw")
+    vault_pass = ws / "secrets" / "vault_pass.txt"
+    vault_pass.parent.mkdir(parents=True)
+    vault_pass.write_text("x")
+    # No default_vault.yml -> nothing to unlock, fall back to ambient ~/.ssh.
+    assert unlock_workspace_keys(ws, vault_pass) is None
+
+
+def test_returns_none_when_no_keys(tmp_path):
+    ws = tmp_path / "A-b"
+    vault_pass = ws / "secrets" / "vault_pass.txt"
+    vault_pass.parent.mkdir(parents=True)
+    vault_pass.write_text("vaultpw")
+    _make_vault(ws / "secrets" / "default_vault.yml",
+                {"ssh_passphrase_deployer_admin": "pw"}, vault_pass)
+    (ws / "ssh_keys").mkdir()
+    assert unlock_workspace_keys(ws, vault_pass) is None
+
+
+def test_loads_passphraseless_key(tmp_path):
+    # context_ssh_keys_use_passphrase=NO: key has no passphrase, no vault field.
+    ws = tmp_path / "A-b"
+    vault_pass = ws / "secrets" / "vault_pass.txt"
+    vault_pass.parent.mkdir(parents=True)
+    vault_pass.write_text("vaultpw")
+    _gen_key(ws / "ssh_keys" / "backend_keys"
+             / "r42.A-b-deployer-key_alice", "")
+    _make_vault(ws / "secrets" / "default_vault.yml",
+                {"ssh_passphrase_deployer_admin": ""}, vault_pass)
+    handle = unlock_workspace_keys(ws, vault_pass)
+    try:
+        assert handle is not None
+        assert _agent_key_count(handle.env["SSH_AUTH_SOCK"]) == 1
+    finally:
+        if handle is not None:
+            handle.close()
+
+
+def test_loads_multiple_key_families_including_extra_student(tmp_path):
+    ws = tmp_path / "ALPHA-demo"
+    vault_pass = ws / "secrets" / "vault_pass.txt"
+    vault_pass.parent.mkdir(parents=True)
+    vault_pass.write_text("vaultpw")
+    kd = ws / "ssh_keys"
+    _gen_key(kd / "backend_keys" / "r42.ALPHA-demo-deployer-key_alice", "pa")
+    _gen_key(kd / "student_keys" / "r42.ALPHA-demo-student-key_bob", "pb")
+    _gen_key(kd / "student_keys" / "additional.students"
+             / "r42.ALPHA-demo-student-key_bob_1", "pe")
+    _gen_key(kd / "jump_keys" / "px.ALPHA-demo-ssh_cli.root", "pr")
+    _make_vault(ws / "secrets" / "default_vault.yml", {
+        "ssh_passphrase_deployer_admin": "pa",
+        "ssh_passphrase_student_user": "pb",
+        "ssh_passphrase_student_user_extra_all": "pe",
+        "ssh_passphrase_px_root": "pr",
+    }, vault_pass)
+    handle = unlock_workspace_keys(ws, vault_pass)
+    try:
+        assert handle is not None
+        assert _agent_key_count(handle.env["SSH_AUTH_SOCK"]) == 4
+    finally:
+        if handle is not None:
+            handle.close()
+
+
+def test_close_kills_agent(tmp_path):
+    ws = tmp_path / "A-b"
+    vault_pass = ws / "secrets" / "vault_pass.txt"
+    vault_pass.parent.mkdir(parents=True)
+    vault_pass.write_text("vaultpw")
+    _gen_key(ws / "ssh_keys" / "backend_keys"
+             / "r42.A-b-deployer-key_alice", "pw")
+    _make_vault(ws / "secrets" / "default_vault.yml",
+                {"ssh_passphrase_deployer_admin": "pw"}, vault_pass)
+    handle = unlock_workspace_keys(ws, vault_pass)
+    assert handle is not None
+    sock = handle.env["SSH_AUTH_SOCK"]
+    assert _agent_key_count(sock) == 1
+    handle.close()
+    # After close the agent socket is dead -> ssh-add -l can't list keys.
+    assert _agent_key_count(sock) == 0

--- a/tests/routes/test_catalog_clone_auth.py
+++ b/tests/routes/test_catalog_clone_auth.py
@@ -1,0 +1,74 @@
+"""Catalog-source git clones must authenticate with the Source's PAT and must
+never leak that token in an error path."""
+from pathlib import Path
+
+import pytest
+
+from app.core.errors import SourceUnreachableError
+from app.core.models import Source, SourceRepo
+
+
+def _src_repo():
+    src = Source(id="s", provider="github", base_url="https://github.com",
+                 auth_kind="pat", token_ref="ghp_SECRET")
+    repo = SourceRepo(source_id="s", owner="o", repo="r", branch="main")
+    return src, repo
+
+
+def test_entries_clone_embeds_token(monkeypatch, tmp_path):
+    from app.routes.v1.catalog import entries
+    captured = {}
+
+    class _FakeRepo:
+        @staticmethod
+        def clone_from(url, dest, **kw):
+            captured["url"] = url
+            Path(dest).mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(entries.git, "Repo", _FakeRepo)
+    src, repo = _src_repo()
+    entries._clone_repo(src, repo, tmp_path)
+    assert "x-access-token:ghp_SECRET@github.com" in captured["url"]
+
+
+def test_entries_clone_error_is_redacted(monkeypatch, tmp_path):
+    from app.routes.v1.catalog import entries
+
+    class _BoomRepo:
+        @staticmethod
+        def clone_from(url, dest, **kw):
+            raise RuntimeError(f"fatal: could not read from {url}")
+
+    monkeypatch.setattr(entries.git, "Repo", _BoomRepo)
+    src, repo = _src_repo()
+    with pytest.raises(SourceUnreachableError) as ei:
+        entries._clone_repo(src, repo, tmp_path)
+    assert "ghp_SECRET" not in str(ei.value.details)
+
+
+def test_refresh_clone_embeds_token_and_redacts(monkeypatch, tmp_path):
+    import git as gitmod
+
+    from app.routes.v1.catalog import refresh
+    captured = {}
+
+    class _FakeRepo:
+        @staticmethod
+        def clone_from(url, dest, **kw):
+            captured["url"] = url
+            Path(dest).mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(gitmod, "Repo", _FakeRepo)
+    src, repo = _src_repo()
+    refresh._count_entries_in_repo(src, repo)
+    assert "x-access-token:ghp_SECRET@github.com" in captured["url"]
+
+    class _BoomRepo:
+        @staticmethod
+        def clone_from(url, dest, **kw):
+            raise RuntimeError(f"fatal: {url}")
+
+    monkeypatch.setattr(gitmod, "Repo", _BoomRepo)
+    with pytest.raises(Exception) as ei:
+        refresh._count_entries_in_repo(src, repo)
+    assert "ghp_SECRET" not in str(ei.value)

--- a/tests/routes/test_catalog_sources.py
+++ b/tests/routes/test_catalog_sources.py
@@ -55,6 +55,39 @@ async def test_source_crud_roundtrip(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_source_responses_never_leak_the_token(tmp_path, monkeypatch):
+    """POST and GET /v1/catalog/sources must not echo the Git PAT back; they
+    expose only a has_token boolean."""
+    app, dbmod = await _boot(tmp_path, monkeypatch)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://t"
+        ) as c:
+            r = await c.post(
+                "/v1/catalog/sources",
+                json={
+                    "provider": "github",
+                    "base_url": "https://github.com",
+                    "auth_kind": "pat",
+                    "token_ref": "ghp_SUPERSECRET",
+                },
+            )
+            assert r.status_code == 201, r.text
+            assert "ghp_SUPERSECRET" not in r.text
+            assert "token_ref" not in r.json()
+            assert r.json()["has_token"] is True
+
+            r = await c.get("/v1/catalog/sources")
+            assert r.status_code == 200
+            assert "ghp_SUPERSECRET" not in r.text
+            item = r.json()["items"][0]
+            assert "token_ref" not in item
+            assert item["has_token"] is True
+    finally:
+        await dbmod.dispose_engine()
+
+
+@pytest.mark.asyncio
 async def test_delete_unknown_source_returns_canonical_envelope(tmp_path, monkeypatch):
     app, dbmod = await _boot(tmp_path, monkeypatch)
     try:


### PR DESCRIPTION
Backend side of range42/range42-playbooks#131 (align the deployer-ui/backend bundle config contract). Three commits, all TDD; full suite green except the pre-existing overlay failure (#84).

**compose .env drives runtime config** (`ec8c1bf`)
`docker-compose.yml` hard-coded `API_BACKEND_WWWAPP_PLAYBOOKS_DIR=/app/`, overriding the deploy bundle's `.env` — so the RO playbooks bind-mount was never read (baked-in `/app/` has no `scenarios/`). Now `.env`-driven via `env_file` (required:false) + `${VAR:-default}`.

**In-container SSH-key unlock** (`0a9dc2f`) — answers Ben's SSH question
range42 deploy keys are passphrase-protected (per-family passphrase in the workspace vault). The container has no ssh-agent, so ansible-runner couldn't reach the VMs. New `app/core/ssh_agent.py` decrypts the vault with `vault_pass.txt`, starts an ssh-agent, and `ssh-add`s the keys via the same SSH_ASKPASS mechanism `range42-context` uses; wired into `deploy_trigger.start_attempt` (SSH_AUTH_SOCK into the runner env, agent closed after). **Keys stay passphrase-protected — nothing changes on the deployer-cli side.**

**Git PAT hardening** (`e6f5fae`) — makes it safe to wire the source seed
- `SourceOut` no longer returns `token_ref` (exposes `has_token: bool`). The deployer-ui never read the token back.
- catalog clones (`entries`, `refresh`) now authenticate with the token and redact it from errors.
- `checkout_project` fetches the URL ad-hoc instead of `git remote add origin`, so the PAT is no longer persisted in the workspace `.git/config`.

**Deferred (flagged):** `projects/compose.py` base-catalog clone (different repo/token scope); token-at-rest encryption (needs a secret-store decision); Proxmox `HostOut` token_ref (separate credential).

Refs range42/range42-playbooks#131.