### PR TITLE
fix(security): stop returning Proxmox token_ref in API responses (#100)

### DIFF
--- a/app/routes/v1/proxmox/hosts.py
+++ b/app/routes/v1/proxmox/hosts.py
@@ -38,7 +38,7 @@ def _row_to_out(row: ProxmoxHost) -> HostOut:
         name=row.name,
         api_url=row.api_url,
         node_name=row.node_name,
-        token_ref=row.token_ref,
+        has_token=bool(row.token_ref),
         token_scope=row.token_scope,
         default_bridge=row.default_bridge,
         protected_vmids_override=overrides,

--- a/app/schemas/v1/proxmox.py
+++ b/app/schemas/v1/proxmox.py
@@ -18,8 +18,22 @@ class HostIn(BaseModel):
     protected_vmids_override: list[list[int]] | None = None
 
 
-class HostOut(HostIn):
+class HostOut(BaseModel):
+    """Response shape for a registered host.
+
+    Deliberately does NOT inherit from ``HostIn``: that would carry
+    ``token_ref`` — the live ``PVEAPIToken`` secret — into every response
+    (#100). Only whether a token is stored is exposed.
+    """
+
     id: str
+    name: str
+    api_url: HttpUrl
+    node_name: str
+    has_token: bool = False
+    token_scope: str | None = None
+    default_bridge: str = "vmbr0"
+    protected_vmids_override: list[list[int]] | None = None
     added_at: datetime
     last_health_check: dict | None = None
 

--- a/openapi.json
+++ b/openapi.json
@@ -6485,6 +6485,10 @@
       },
       "HostOut": {
         "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
           "name": {
             "type": "string",
             "title": "Name"
@@ -6500,9 +6504,10 @@
             "type": "string",
             "title": "Node Name"
           },
-          "token_ref": {
-            "type": "string",
-            "title": "Token Ref"
+          "has_token": {
+            "type": "boolean",
+            "title": "Has Token",
+            "default": false
           },
           "token_scope": {
             "anyOf": [
@@ -6537,10 +6542,6 @@
             ],
             "title": "Protected Vmids Override"
           },
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
           "added_at": {
             "type": "string",
             "format": "date-time",
@@ -6561,14 +6562,14 @@
         },
         "type": "object",
         "required": [
+          "id",
           "name",
           "api_url",
           "node_name",
-          "token_ref",
-          "id",
           "added_at"
         ],
-        "title": "HostOut"
+        "title": "HostOut",
+        "description": "Response shape for a registered host.\n\nDeliberately does NOT inherit from ``HostIn``: that would carry\n``token_ref`` \u2014 the live ``PVEAPIToken`` secret \u2014 into every response\n(#100). Only whether a token is stored is exposed."
       },
       "NodeNetworkAddItemReply": {
         "properties": {

--- a/tests/routes/test_no_token_in_responses.py
+++ b/tests/routes/test_no_token_in_responses.py
@@ -1,0 +1,128 @@
+"""Secrets must never be echoed back by the API (#100).
+
+`token_ref` holds the live Proxmox API token and Git PATs. Any caller able to
+reach the backend could otherwise harvest every registered credential with a
+single GET — amplified by the subnet-wide CORS default (#101).
+
+These tests assert on the serialized response bodies, not on the models, so
+they keep holding if someone re-adds the field through a different route.
+"""
+import json
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+TOKEN = "root@pam!deployer=1234abcd-dead-beef-0000-feedfacecafe"
+PAT = "ghp_averysecretpersonalaccesstoken00000000"
+
+
+async def _boot(tmp_path, monkeypatch):
+    db = tmp_path / "t.db"
+    monkeypatch.setenv("RANGE42_DB_URL", f"sqlite+aiosqlite:///{db}")
+    monkeypatch.setenv("RANGE42_WORKSPACE_ROOT", str(tmp_path))
+    from importlib import reload
+
+    from app.core import config as cfg
+    reload(cfg)
+    import app.core.db as dbmod
+    reload(dbmod)
+    from app.core.models import Base
+
+    engine = dbmod.get_engine()
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    from app.main import create_app
+    return create_app()
+
+
+def _assert_no_secret(payload):
+    blob = json.dumps(payload)
+    for secret in (TOKEN, PAT):
+        assert secret not in blob, f"response leaked a secret: {payload}"
+    return blob
+
+
+@pytest.mark.asyncio
+async def test_proxmox_host_responses_never_include_token(tmp_path, monkeypatch):
+    app = await _boot(tmp_path, monkeypatch)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://t"
+    ) as c:
+        created = await c.post("/v1/proxmox/hosts", json={
+            "name": "pve01",
+            "api_url": "https://10.0.0.5:8006",
+            "node_name": "pve01",
+            "token_ref": TOKEN,
+            "token_scope": "PVEVMAdmin",
+        })
+        assert created.status_code == 201, created.text
+        body = created.json()
+        assert "token_ref" not in _assert_no_secret(body)
+        assert body["has_token"] is True
+
+        listed = await c.get("/v1/proxmox/hosts")
+        assert listed.status_code == 200
+        assert "token_ref" not in _assert_no_secret(listed.json())
+        assert listed.json()["items"][0]["has_token"] is True
+
+
+@pytest.mark.asyncio
+async def test_catalog_source_responses_never_include_token(tmp_path, monkeypatch):
+    """The Git PAT half of #100 — kept alongside so both are covered here."""
+    app = await _boot(tmp_path, monkeypatch)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://t"
+    ) as c:
+        created = await c.post("/v1/catalog/sources", json={
+            "provider": "github",
+            "base_url": "https://github.com",
+            "auth_kind": "pat",
+            "token_ref": PAT,
+        })
+        assert created.status_code in (200, 201), created.text
+        assert "token_ref" not in _assert_no_secret(created.json())
+
+        listed = await c.get("/v1/catalog/sources")
+        assert listed.status_code == 200
+        assert "token_ref" not in _assert_no_secret(listed.json())
+
+
+@pytest.mark.asyncio
+async def test_openapi_response_schemas_expose_no_token_ref(tmp_path, monkeypatch):
+    """No *response* schema may declare token_ref; request bodies still may."""
+    app = await _boot(tmp_path, monkeypatch)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://t"
+    ) as c:
+        spec = (await c.get("/docs/openapi.json")).json()
+
+    schemas = spec["components"]["schemas"]
+
+    def _leaks(schema: dict) -> str:
+        """Return the offending component name if this schema exposes a token."""
+        ref = schema.get("$ref") or (schema.get("items") or {}).get("$ref", "")
+        name = ref.rsplit("/", 1)[-1] if ref else ""
+        if not name:
+            return ""
+        props = schemas.get(name, {}).get("properties", {})
+        if "token_ref" in props:
+            return name
+        # Page[T] wrappers nest the payload under items
+        nested = (props.get("items") or {}).get("items", {})
+        return _leaks(nested) if nested else ""
+
+    offenders = []
+    for path, ops in spec["paths"].items():
+        for method, op in ops.items():
+            if not isinstance(op, dict):
+                continue
+            for code, resp in (op.get("responses") or {}).items():
+                schema = ((resp.get("content") or {})
+                          .get("application/json", {})
+                          .get("schema", {}))
+                bad = _leaks(schema)
+                if bad:
+                    offenders.append(f"{method.upper()} {path} -> {code} ({bad})")
+
+    assert not offenders, f"response schemas expose token_ref: {offenders}"


### PR DESCRIPTION
Closes #100.

`HostOut` inherited from `HostIn`, so `token_ref` — the live `PVEAPIToken` secret — was returned by `GET /v1/proxmox/hosts` and by every create response. One request harvests every registered Proxmox credential, and the subnet-wide CORS default (#101) means any LAN device can make it.

#112 fixed the Git PAT half (`SourceOut` → `has_token`); this is the Proxmox half, done the same way.

## Change

`HostOut` is no longer a subclass of `HostIn` — it declares its own fields and exposes `has_token: bool` in place of `token_ref`. Request bodies are untouched: you still POST `token_ref` to register a host.

## Tests

Three, asserting on **serialized response bodies** rather than on the models, so the guarantee survives someone re-adding the field elsewhere:

- host create + list never contain the token string, and report `has_token: true`
- the same for catalog sources (the #112 half, kept alongside so both live in one place)
- a sweep over the generated OpenAPI asserting **no response schema anywhere** declares `token_ref`, including through `Page[T]` wrappers — this one failed on `GET /v1/proxmox/hosts` and `POST /v1/proxmox/hosts` before the fix

423 passed. `openapi.json` regenerated.

## Not breaking the UI

deployer-ui reads only `id` and `node_name` from `/v1/proxmox/hosts` (`src/services/proxmox/api.ts` `getRegisteredHost`) and never writes hosts — `proxmoxSettingsStore.ts:117` documents that host CRUD was deliberately removed from the UI. Zero references to `token_ref` or `has_token` anywhere in the UI.

## Scope

This closes the *echo-back* problem only. Tokens are still stored in the DB in plaintext and treated as literal secrets by the deploy path — that is #75 (secret reference) and #86 (at-rest), both still open. The remaining `token_ref` reads in `deploy_trigger.py` and `preflight.py` are usage, not exposure; I checked the host-health error paths and they surface the field *name*, never the value.