### PR TITLE
feat(infra): GET /v1/infra/mirror/health — the route the canvas mirror node already polls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,11 @@ API_BACKEND_PUBLIC_PLAYBOOKS_DIR=     # External playbooks repo path
 API_BACKEND_INVENTORY_DIR=            # Ansible inventory directory
 API_BACKEND_VAULT_FILE=               # Vault-encrypted variables file
 
+# APT Mirror (infra health endpoint)
+APT_MIRROR_HOST=            # Hostname or IP of the apt-mirror VM
+APT_MIRROR_NGINX_PORT=80    # nginx port on the mirror VM
+APT_MIRROR_AIRGAPPED=       # Set to "true" if using aptly (air-gapped mode)
+
 # Optional
 CORS_ORIGIN_REGEX=          # Custom CORS regex (default: localhost only)
 HOST=0.0.0.0                # Server bind address

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ logs/
 # claude
 CLAUDE.md
 
+
+# Ansible collections installed locally via ansible-galaxy (see requirements.yml)
+collections/

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter
 
+from app.routes.infra import router as infra_router
 from app.routes.debug import router as debug_router
 from app.routes.firewall import router as firewall_router
 from app.routes.network import router as network_router
@@ -10,6 +11,9 @@ from app.routes.vm_config import router as vm_config_router
 from app.routes.vms import vm_id_router, vms_router
 
 router = APIRouter()
+
+# /v1/infra/* — new surface goes on v1; v0 is legacy and shrinking.
+router.include_router(infra_router, prefix="/v1/infra")
 
 # /v0/admin/debug/*
 router.include_router(debug_router, prefix="/v0/admin/debug")

--- a/app/routes/infra.py
+++ b/app/routes/infra.py
@@ -1,0 +1,66 @@
+"""Infrastructure health routes.
+
+Endpoints
+---------
+- ``GET /v1/infra/mirror/health`` -- APT mirror health status.
+"""
+
+import os
+
+import httpx
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+router = APIRouter()
+
+_MIRROR_REPORT_PATH = "/acng-report.html"
+
+
+def _mirror_base_url() -> str:
+    host = os.getenv("APT_MIRROR_HOST", "")
+    port = os.getenv("APT_MIRROR_NGINX_PORT", "80")
+    return f"http://{host}:{port}"
+
+
+@router.get(
+    path="/mirror/health",
+    summary="APT mirror health",
+    description="Returns health status and basic stats for the local APT mirror.",
+    tags=["infra"],
+)
+def infra_mirror_health() -> JSONResponse:
+    """Proxy the apt-cacher-ng report page and return structured health info.
+
+    :returns: JSON with status, backend, and report URL.
+    :rtype: JSONResponse
+    """
+    if not os.getenv("APT_MIRROR_HOST"):
+        return JSONResponse(
+            {"status": "unconfigured", "detail": "APT_MIRROR_HOST not set"},
+            status_code=503,
+        )
+
+    base = _mirror_base_url()
+
+    try:
+        resp = httpx.get(f"{base}{_MIRROR_REPORT_PATH}", timeout=5.0)
+        if resp.status_code == 200:
+            return JSONResponse(
+                {
+                    "status": "healthy",
+                    "backend": "aptly" if os.getenv("APT_MIRROR_AIRGAPPED") else "acng",
+                    "report_url": f"{base}{_MIRROR_REPORT_PATH}",
+                }
+            )
+        return JSONResponse(
+            {"status": "degraded", "http_status": resp.status_code},
+            status_code=502,
+        )
+    except httpx.ConnectError:
+        return JSONResponse({"status": "offline", "detail": "connection refused"}, status_code=503)
+    except httpx.TimeoutException:
+        return JSONResponse({"status": "offline", "detail": "timeout"}, status_code=503)

--- a/openapi.json
+++ b/openapi.json
@@ -11,6 +11,26 @@
     "version": "v0.1"
   },
   "paths": {
+    "/v1/infra/mirror/health": {
+      "get": {
+        "tags": [
+          "infra"
+        ],
+        "summary": "APT mirror health",
+        "description": "Returns health status and basic stats for the local APT mirror.",
+        "operationId": "infra_mirror_health_v1_infra_mirror_health_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
     "/v0/admin/debug/ping": {
       "post": {
         "tags": [

--- a/tests/routes/test_infra_mirror.py
+++ b/tests/routes/test_infra_mirror.py
@@ -1,0 +1,71 @@
+"""GET /v1/infra/mirror/health — the endpoint InfraNodeMirror.vue polls."""
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+REPORT = "/acng-report.html"
+
+
+@pytest.fixture
+def client(monkeypatch):
+    from app.main import app
+    return TestClient(app)
+
+
+def test_unconfigured_when_host_unset(client, monkeypatch):
+    monkeypatch.delenv("APT_MIRROR_HOST", raising=False)
+    r = client.get("/v1/infra/mirror/health")
+    assert r.status_code == 503
+    assert r.json()["status"] == "unconfigured"
+
+
+def test_healthy_reports_backend_and_report_url(client, monkeypatch):
+    monkeypatch.setenv("APT_MIRROR_HOST", "10.0.0.9")
+    monkeypatch.setenv("APT_MIRROR_NGINX_PORT", "8080")
+    monkeypatch.delenv("APT_MIRROR_AIRGAPPED", raising=False)
+    monkeypatch.setattr(
+        "app.routes.infra.httpx.get",
+        lambda url, timeout=None: httpx.Response(200, request=httpx.Request("GET", url)),
+    )
+    body = client.get("/v1/infra/mirror/health").json()
+    assert body["status"] == "healthy"
+    assert body["backend"] == "acng"
+    assert body["report_url"] == f"http://10.0.0.9:8080{REPORT}"
+
+
+def test_airgapped_flag_switches_backend_label(client, monkeypatch):
+    monkeypatch.setenv("APT_MIRROR_HOST", "10.0.0.9")
+    monkeypatch.setenv("APT_MIRROR_AIRGAPPED", "true")
+    monkeypatch.setattr(
+        "app.routes.infra.httpx.get",
+        lambda url, timeout=None: httpx.Response(200, request=httpx.Request("GET", url)),
+    )
+    assert client.get("/v1/infra/mirror/health").json()["backend"] == "aptly"
+
+
+def test_non_200_is_degraded(client, monkeypatch):
+    monkeypatch.setenv("APT_MIRROR_HOST", "10.0.0.9")
+    monkeypatch.setattr(
+        "app.routes.infra.httpx.get",
+        lambda url, timeout=None: httpx.Response(500, request=httpx.Request("GET", url)),
+    )
+    r = client.get("/v1/infra/mirror/health")
+    assert r.status_code == 502
+    assert r.json() == {"status": "degraded", "http_status": 500}
+
+
+@pytest.mark.parametrize("exc,detail", [
+    (httpx.ConnectError("refused"), "connection refused"),
+    (httpx.TimeoutException("timeout"), "timeout"),
+])
+def test_transport_failures_are_offline(client, monkeypatch, exc, detail):
+    """The node polls every 30s — a down mirror must not surface as a 500."""
+    monkeypatch.setenv("APT_MIRROR_HOST", "10.0.0.9")
+
+    def _boom(url, timeout=None):
+        raise exc
+
+    monkeypatch.setattr("app.routes.infra.httpx.get", _boom)
+    r = client.get("/v1/infra/mirror/health")
+    assert r.status_code == 503
+    assert r.json() == {"status": "offline", "detail": detail}


### PR DESCRIPTION
Salvaged from `feat/local-apt-mirror` (`87de7eb`), which has sat unmerged since 20 May. Checked while cleaning up stale branches: **there is no v1 replacement — there is no replacement at all.**

`deployer-ui` `dev` ships `src/components/nodes/InfraNodeMirror.vue`, which polls `/v0/infra/mirror/health` every 30 seconds. No such route exists on backend `dev` (`app/routes/infra.py` does not exist there, and nothing references `APT_MIRROR_*`), so **the mirror node has always rendered offline** — the same failure mode as the `/v1/.../vms/{vmid}/config` route the UI was calling in #98.

## Changes from the original commit

- **Mounted under `/v1`, not `/v0`.** This is new surface, and v0 is legacy and shrinking (#113 removed a large chunk of it today). deployer-ui `9ac8258` updates the fetch path in lockstep, so the two land together.
- **Project logger** (`app.core.logging.get_logger`) instead of stdlib `logging`.
- **Tests** — the original had none, and ruff + pytest now gate CI (#92). Six cases: unconfigured, healthy, air-gapped backend label, degraded on non-200, and both transport failures. That last pair matters: the node polls on a timer, so a mirror that is down must report `offline`, not surface a 500.

Authorship of the original commit is preserved.

## Also in here

`.gitignore` now excludes `collections/` — `ansible-galaxy install -p ./collections` drops ~4200 vendored files into the worktree, and they nearly ended up committed.

443 passed, ruff clean, `openapi.json` regenerated.

Once this merges, `feat/local-apt-mirror` can be deleted; its only commit is superseded by this one.