### PR TITLE
fix(infra): all httpx transport failures are offline; parse APT_MIRROR_AIRGAPPED as a boolean

### DIFF
--- a/app/routes/infra.py
+++ b/app/routes/infra.py
@@ -26,6 +26,20 @@ def _mirror_base_url() -> str:
     return f"http://{host}:{port}"
 
 
+def _airgapped() -> bool:
+    """Whether the mirror is aptly (air-gapped) rather than apt-cacher-ng.
+
+    Parsed as a boolean, not mere presence: a deployment that sets
+    ``APT_MIRROR_AIRGAPPED=false`` means acng, but any non-empty string is
+    truthy. Matches the ``("1", "true", "yes")`` convention in core.config.
+    """
+    return os.getenv("APT_MIRROR_AIRGAPPED", "").lower() in ("1", "true", "yes")
+
+
+def _offline(detail: str) -> JSONResponse:
+    return JSONResponse({"status": "offline", "detail": detail}, status_code=503)
+
+
 @router.get(
     path="/mirror/health",
     summary="APT mirror health",
@@ -52,7 +66,7 @@ def infra_mirror_health() -> JSONResponse:
             return JSONResponse(
                 {
                     "status": "healthy",
-                    "backend": "aptly" if os.getenv("APT_MIRROR_AIRGAPPED") else "acng",
+                    "backend": "aptly" if _airgapped() else "acng",
                     "report_url": f"{base}{_MIRROR_REPORT_PATH}",
                 }
             )
@@ -60,7 +74,15 @@ def infra_mirror_health() -> JSONResponse:
             {"status": "degraded", "http_status": resp.status_code},
             status_code=502,
         )
-    except httpx.ConnectError:
-        return JSONResponse({"status": "offline", "detail": "connection refused"}, status_code=503)
     except httpx.TimeoutException:
-        return JSONResponse({"status": "offline", "detail": "timeout"}, status_code=503)
+        return _offline("timeout")
+    except httpx.ConnectError:
+        return _offline("connection refused")
+    except httpx.RequestError as exc:
+        # Everything else httpx can raise while talking to the mirror —
+        # ReadError, RemoteProtocolError, a reset mid-response. The canvas
+        # node polls this every 30s, so a broken mirror must read as offline
+        # rather than a 500 that makes the backend look at fault.
+        logger.warning("mirror health transport error",
+                       error=type(exc).__name__, detail=str(exc))
+        return _offline(type(exc).__name__)

--- a/tests/routes/test_infra_mirror.py
+++ b/tests/routes/test_infra_mirror.py
@@ -57,6 +57,13 @@ def test_non_200_is_degraded(client, monkeypatch):
 @pytest.mark.parametrize("exc,detail", [
     (httpx.ConnectError("refused"), "connection refused"),
     (httpx.TimeoutException("timeout"), "timeout"),
+    (httpx.ConnectTimeout("connect timed out"), "timeout"),
+    # Mirror accepted the connection then broke it — these are the ones the
+    # first version missed, and they surfaced as 500s.
+    (httpx.ReadError("reset"), "ReadError"),
+    (httpx.RemoteProtocolError("truncated"), "RemoteProtocolError"),
+    (httpx.WriteError("broken pipe"), "WriteError"),
+    (httpx.ProtocolError("bad framing"), "ProtocolError"),
 ])
 def test_transport_failures_are_offline(client, monkeypatch, exc, detail):
     """The node polls every 30s — a down mirror must not surface as a 500."""
@@ -69,3 +76,18 @@ def test_transport_failures_are_offline(client, monkeypatch, exc, detail):
     r = client.get("/v1/infra/mirror/health")
     assert r.status_code == 503
     assert r.json() == {"status": "offline", "detail": detail}
+
+
+@pytest.mark.parametrize("value,expected", [
+    ("true", "aptly"), ("True", "aptly"), ("1", "aptly"), ("yes", "aptly"),
+    # Explicitly disabling it must mean acng — presence alone is not truth.
+    ("false", "acng"), ("0", "acng"), ("no", "acng"), ("", "acng"),
+])
+def test_airgapped_flag_is_parsed_as_boolean(client, monkeypatch, value, expected):
+    monkeypatch.setenv("APT_MIRROR_HOST", "10.0.0.9")
+    monkeypatch.setenv("APT_MIRROR_AIRGAPPED", value)
+    monkeypatch.setattr(
+        "app.routes.infra.httpx.get",
+        lambda url, timeout=None: httpx.Response(200, request=httpx.Request("GET", url)),
+    )
+    assert client.get("/v1/infra/mirror/health").json()["backend"] == expected


### PR DESCRIPTION
Both findings from the Codex review on #124. Both are real, and both were partly my fault — see the last section.

## 1. Transport failures other than connect/timeout returned 500

A mirror that accepts the connection and *then* breaks it raises `ReadError`, `RemoteProtocolError` or `WriteError`. The handler caught only `ConnectError` and `TimeoutException`, so those escaped as a 500 from an endpoint that documents `offline`. The canvas node polls every 30s, so a broken mirror made the *backend* look at fault.

Now catches `httpx.RequestError` as the floor — it is the base of the whole transport family — keeping the specific `timeout` and `connection refused` details for the two common cases and logging the exception type for anything else.

## 2. `APT_MIRROR_AIRGAPPED=false` reported the aptly backend

The flag was read for presence, so any non-empty value was truthy — including `false` and `0`. Parsed now with the same `("1", "true", "yes")` convention `core.config` uses for `DEBUG` and friends.

## The tests were the reason neither showed up

My suite in #124 parametrised exactly the two exception types the code already caught, and only tested the air-gapped flag in its set state. That is test-shaped-like-the-implementation, and it certified a contract narrower than the docstring promised.

Now: six transport types (`ConnectError`, `TimeoutException`, `ConnectTimeout`, `ReadError`, `RemoteProtocolError`, `WriteError`, `ProtocolError`) and eight flag values across truthy and falsy. Verified they fail against the pre-fix file — 6 failures, exactly the two gaps:

```
FAILED test_transport_failures_are_offline[exc4-RemoteProtocolError]
FAILED test_transport_failures_are_offline[exc5-WriteError]
FAILED test_transport_failures_are_offline[exc6-ProtocolError]
FAILED test_airgapped_flag_is_parsed_as_boolean[false-acng]
FAILED test_airgapped_flag_is_parsed_as_boolean[0-acng]
FAILED test_airgapped_flag_is_parsed_as_boolean[no-acng]
```

456 passed, ruff clean.