### PR TITLE
fix(overlay): nullish scope fallback and untruncated vmid offsets

### DIFF
--- a/app/overlay/expand_replication.py
+++ b/app/overlay/expand_replication.py
@@ -188,8 +188,11 @@ def _apply_offsets(node: dict, team_id: int,
             and "vm_id" in cfg):
         base_vmid = _js_number(cfg["vm_id"])
         if base_vmid is not None:
+            # Multiply by the raw offset, not int(): TS does plain number
+            # arithmetic, so a fractional vmid offset must stay fractional.
+            # Truncating gave every team the same id — duplicate VMIDs.
             cfg["vm_id"] = _num_to_str_value(
-                base_vmid + int(id_offset["vmid"]) * team_id)
+                base_vmid + id_offset["vmid"] * team_id)
     out["config"] = cfg
     for tkey, okey in _NODE_TEMPLATES:
         if isinstance(out.get(tkey), str):
@@ -227,8 +230,11 @@ def _walk_and_expand(nodes: list[dict], team_count: int,
         rep = raw_rep if isinstance(raw_rep, dict) else {}
         # `scope:` with no value is a present key holding None — .get(k, default)
         # would return None and fall through to the per_team branch, expanding
-        # a node the author marked shared. TS coalesces with ??; mirror that.
-        scope = rep.get("scope") or "shared"
+        # a node the author marked shared. TS coalesces with ??, which is
+        # nullish and NOT truthiness: false / 0 / "" keep their value and fall
+        # through to per_team. `or` would swallow them into "shared".
+        raw_scope = rep.get("scope")
+        scope = "shared" if raw_scope is None else raw_scope
         if scope == "shared":
             if n.get("kind") == "group" and isinstance(n.get("children"), list):
                 nn = deepcopy(n)

--- a/tests/overlay/test_expand_replication_parity.py
+++ b/tests/overlay/test_expand_replication_parity.py
@@ -1,0 +1,55 @@
+"""JS-semantics parity cases that the shared vectors do not cover.
+
+These pin coercion rules where Python's natural spelling diverges from the
+TS mirror — the kind of thing that only shows up on loosely-typed YAML.
+"""
+import pytest
+
+from app.overlay.expand_replication import expand_replication
+
+
+def _node(**kw):
+    return {"nodes": [{"id": "a", **kw}]}
+
+
+@pytest.mark.parametrize("scope", [False, 0, ""])
+def test_falsy_but_non_null_scope_still_expands(scope):
+    """TS uses `??`, which is nullish — only null/undefined mean shared.
+
+    `or` would swallow false/0/"" into "shared" and silently drop every
+    per-team copy.
+    """
+    got = expand_replication(_node(replication={"scope": scope}), 2)
+    ids = [n["id"] for n in got["document"]["nodes"]]
+    assert ids == ["a__team_1", "a__team_2"]
+
+
+@pytest.mark.parametrize("scope", [None, "shared"])
+def test_null_or_missing_scope_is_shared(scope):
+    rep = {} if scope is None else {"scope": scope}
+    got = expand_replication(_node(replication=rep), 2)
+    assert [n["id"] for n in got["document"]["nodes"]] == ["a"]
+
+
+def test_explicit_null_scope_is_shared():
+    got = expand_replication(_node(replication={"scope": None}), 2)
+    assert [n["id"] for n in got["document"]["nodes"]] == ["a"]
+
+
+def test_fractional_vmid_offset_is_not_truncated():
+    """int() on the offset gave every team the same vm_id — duplicate VMIDs."""
+    got = expand_replication(
+        _node(replication={"scope": "per_team", "id_offset": {"vmid": 0.5}},
+              config={"vm_id": 100}),
+        2,
+    )
+    assert [n["config"]["vm_id"] for n in got["document"]["nodes"]] == [100.5, 101]
+
+
+def test_integral_vmid_offset_stays_int():
+    got = expand_replication(
+        _node(replication={"scope": "per_team", "id_offset": {"vmid": 4}},
+              config={"vm_id": 100}),
+        2,
+    )
+    assert [n["config"]["vm_id"] for n in got["document"]["nodes"]] == [104, 108]


### PR DESCRIPTION
Two parity regressions I introduced in #126, both caught by Codex review. Both verified against the TS mirror rather than reasoned about.

## 1. `or` is not `??` — falsy scopes were swallowed

#126 replaced `rep.get("scope", "shared")` with `rep.get("scope") or "shared"`. That is truthiness; the TS mirror uses `??`, which is **nullish**. So `scope: false`, `scope: 0` and `scope: ""` were collapsed to `shared` and **every per-team copy was dropped** — the same class of silent wrong-output that #126 existed to fix, just in the other direction.

| input | TS | Python before | now |
|---|---|---|---|
| `scope: false` / `0` / `""` | 2 per-team nodes | 1 shared node | 2 per-team nodes |
| `scope:` (bare) / missing | 1 shared node | 1 shared node | unchanged |

## 2. `int()` truncated fractional VMID offsets

`int(id_offset["vmid"]) * team_id` truncated before multiplying, so `id_offset: {vmid: 0.5}` gave **every team `vm_id: 100`** — duplicate VMIDs across teams, which is exactly what the offset exists to prevent. TS does plain number arithmetic: 100.5, 101. Integral offsets still yield ints.

## Verification

Re-ran both implementations over all 20 adversarial inputs (the 14 from #118 plus 6 new) via `tsx`, comparing serialized output: **0 divergences**.

The new `tests/overlay/test_expand_replication_parity.py` fails against the previous commit on exactly the four affected cases:

```
FAILED test_falsy_but_non_null_scope_still_expands[False]
FAILED test_falsy_but_non_null_scope_still_expands[0]
FAILED test_falsy_but_non_null_scope_still_expands[]
FAILED test_fractional_vmid_offset_is_not_truncated
```

These live outside the shared vectors deliberately — a vector would have to encode schema-invalid input to exercise them.

464 passed, ruff clean.