### PR TITLE
fix(deploy): make the vault seed atomic with the deployment row

### DIFF
--- a/app/routes/v1/deployments/crud.py
+++ b/app/routes/v1/deployments/crud.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 from fastapi import APIRouter, Depends, status
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
@@ -91,23 +92,52 @@ async def create_deployment(payload: DeploymentCreate,
         workspace_path=str(ws.path),
     )
     session.add(row)
-    await session.commit()
-    await session.refresh(row)
+    # Flush, do not commit: this reserves (codename, scenario_label) at the DB
+    # level — closing the race the pre-check above cannot — while leaving the
+    # transaction open. The secret is written inside that window, so a failed
+    # write rolls the row back and the caller can simply retry. Committing
+    # first would strand a deployment whose workspace has no password, and the
+    # retry would then hit the 409 rather than fixing itself.
+    try:
+        await session.flush()
+    except IntegrityError as e:
+        await session.rollback()
+        raise Range42Error(
+            error="conflict",
+            code="DEPLOYMENT_EXISTS",
+            status=409,
+            message=(
+                f"A deployment named {payload.codename}/"
+                f"{payload.scenario_label} already exists"
+            ),
+            details=[{"field": "codename", "reason": "created concurrently"}],
+        ) from e
 
-    # Everything below mutates the workspace, so it runs only once the row is
-    # persisted — a failed create must never touch another deployment's files.
-    #
     # Seed the workspace vault password: deploy_trigger reads
     # <ws>/secrets/vault_pass.txt to set ANSIBLE_VAULT_PASSWORD_FILE and to
     # unlock the SSH keys for the run, and nothing else writes it. Absent or
     # empty leaves an operator-seeded file alone.
     if payload.secrets and payload.secrets.get("vault_password"):
-        vault_pass_file = ws.path / "secrets" / "vault_pass.txt"
-        vault_pass_file.parent.mkdir(parents=True, exist_ok=True)
-        # chmod before the content so the secret is never briefly world-readable.
-        vault_pass_file.touch(mode=0o600, exist_ok=True)
-        vault_pass_file.chmod(0o600)
-        vault_pass_file.write_text(payload.secrets["vault_password"])
+        try:
+            vault_pass_file = ws.path / "secrets" / "vault_pass.txt"
+            vault_pass_file.parent.mkdir(parents=True, exist_ok=True)
+            # chmod before the content so the secret is never briefly
+            # world-readable.
+            vault_pass_file.touch(mode=0o600, exist_ok=True)
+            vault_pass_file.chmod(0o600)
+            vault_pass_file.write_text(payload.secrets["vault_password"])
+        except OSError as e:
+            await session.rollback()
+            raise Range42Error(
+                error="workspace_error",
+                code="VAULT_SEED_FAILED",
+                status=500,
+                message="Could not write the workspace vault password",
+                details=[{"field": "secrets.vault_password", "reason": str(e)}],
+            ) from e
+
+    await session.commit()
+    await session.refresh(row)
 
     # Best-effort proxmox token provisioning: requires an app-level vault
     # password file and a proxmox_token secret in the payload. Missing

--- a/tests/routes/test_deployment_vault_seed.py
+++ b/tests/routes/test_deployment_vault_seed.py
@@ -5,6 +5,7 @@ unlock the workspace SSH keys (#112). Nothing else wrote it, so a deployment
 created through the API could not decrypt anything — the UI collects the
 password on the deploy form and it had nowhere to go.
 """
+import pathlib
 import stat
 
 import pytest
@@ -159,3 +160,43 @@ async def test_duplicate_codename_is_rejected_without_touching_the_workspace(
     assert body["code"] == "DEPLOYMENT_EXISTS"
     assert first.json()["id"] in str(body["details"])
     assert vault_pass.read_text() == VAULT_PW, "the live deployment was clobbered"
+
+
+@pytest.mark.asyncio
+async def test_failed_seed_leaves_no_deployment_row(tmp_path, monkeypatch):
+    """A write failure must roll the deployment back, not strand it.
+
+    Committing before the seed left a row whose workspace had no password,
+    and the obvious retry then hit the 409 instead of fixing itself — the
+    deployment was unusable until someone deleted it by hand.
+    """
+    app = await _boot(tmp_path, monkeypatch)
+
+    real_write = pathlib.Path.write_text
+
+    def _boom(self, *a, **kw):
+        if self.name == "vault_pass.txt":
+            raise OSError(28, "No space left on device")
+        return real_write(self, *a, **kw)
+
+    monkeypatch.setattr(pathlib.Path, "write_text", _boom)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://t"
+    ) as c:
+        failed = await c.post("/v1/deployments/",
+                              json=_payload(secrets={"vault_password": VAULT_PW}))
+        assert failed.status_code == 500, failed.text
+        assert failed.json()["code"] == "VAULT_SEED_FAILED"
+
+        listed = await c.get("/v1/deployments/")
+        assert listed.json()["items"] == [], "the failed create left a row behind"
+
+        # The obvious next move must work rather than 409.
+        monkeypatch.setattr(pathlib.Path, "write_text", real_write)
+        retry = await c.post("/v1/deployments/",
+                             json=_payload(secrets={"vault_password": VAULT_PW}))
+        assert retry.status_code == 201, retry.text
+
+    vault_pass = tmp_path / "ws" / "ALPHA-demo_lab" / "secrets" / "vault_pass.txt"
+    assert vault_pass.read_text() == VAULT_PW


### PR DESCRIPTION
Second P1 from Codex, this time on my own fix in #130. It is correct — I traded a clobber for an orphan.

## What #130 left behind

#130 moved the secret write *after* `commit()` so a failed create could not touch another deployment's files. But then a failed **write** (disk full, permissions, process death) leaves a committed deployment row whose workspace has no vault password. The obvious retry hits the 409 that PR added, so the deployment is stuck — recoverable only via `DELETE /v1/deployments/{id}`, which nobody would think to reach for.

Both orderings were wrong because the row and the secret were being made durable in separate steps.

## Fix: reserve, write, then commit

`session.flush()` instead of `commit()` issues the INSERT — taking the `(codename, scenario_label)` unique constraint at DB level — while leaving the transaction open. The secret is written inside that window; the commit follows.

- **write fails** → `rollback()`, no row, typed `VAULT_SEED_FAILED`, retry works cleanly
- **concurrent duplicate** slips past the pre-check → surfaces from `flush()` as the same 409 instead of an opaque 500. The pre-check alone was a TOCTOU race; this closes it.
- **no secret supplied** → unchanged

Proxmox token provisioning stays after the commit deliberately: it is best-effort, swallows its own errors, and touches Proxmox rather than the workspace, so it has no bearing on whether the row should exist.

## Test

Patches `Path.write_text` to raise `ENOSPC` for `vault_pass.txt`, then asserts: 500 with `VAULT_SEED_FAILED`, **no deployment row persisted**, and that an immediate retry succeeds with the password on disk. It errors against the previous implementation, where the OSError propagated uncaught and the row survived.

474 passed, ruff clean.