### PR TITLE
ci: fail when the committed openapi.json is out of date (#117)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,23 @@ jobs:
       # since tests/overlay/conftest.py deliberately fails rather than skips
       # when the vectors are missing and CI is set.
       - run: pytest --tb=short -q --ignore=tests/overlay
+
+      # The committed spec bootstraps the Kong gateway config, but nothing
+      # regenerated or verified it — it had rotted back to the pre-v1 API
+      # (84 paths, zero /v1) before #115. Generation is deterministic and
+      # independent of these paths; they only satisfy import-time reads.
+      - name: OpenAPI drift check
+        env:
+          PROJECT_ROOT_DIR: ${{ github.workspace }}
+          API_BACKEND_WWWAPP_PLAYBOOKS_DIR: ${{ github.workspace }}
+          API_BACKEND_PUBLIC_PLAYBOOKS_DIR: ${{ github.workspace }}
+          API_BACKEND_INVENTORY_DIR: ${{ github.workspace }}/inventory
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          python -c "
+          import json
+          from app.main import create_app
+          print(json.dumps(create_app().openapi(), indent=2))
+          " > /tmp/openapi.check.json
+          diff -u openapi.json /tmp/openapi.check.json \
+            || { echo "::error::openapi.json is out of date — regenerate it (see README) and commit"; exit 1; }

--- a/README.md
+++ b/README.md
@@ -139,15 +139,21 @@ VAULT_PASSWORD_FILE=/run/secrets/vault_pass docker compose up
 
 ### OpenAPI spec
 
-The committed `openapi.json` at the repository root reflects the current API surface. It is used to bootstrap the Kong API gateway configuration. To regenerate it after adding or modifying routes:
+The committed `openapi.json` at the repository root reflects the current API surface. It is used to bootstrap the Kong API gateway configuration, and **CI fails if it is out of date** — regenerate and commit it whenever you add or modify a route:
 
 ```bash
+PROJECT_ROOT_DIR=$PWD \
+API_BACKEND_WWWAPP_PLAYBOOKS_DIR=$PWD \
+API_BACKEND_PUBLIC_PLAYBOOKS_DIR=$PWD \
+API_BACKEND_INVENTORY_DIR=$PWD/inventory \
 PYTHONPATH=. python -c "
 import json
 from app.main import create_app
 print(json.dumps(create_app().openapi(), indent=2))
 " > openapi.json
 ```
+
+The environment variables are only there to satisfy import-time reads — several route modules resolve paths at module scope, so the command dies without them. The generated document does not depend on their values.
 
 ---
 


### PR DESCRIPTION
Closes #117.

Nothing regenerated or verified the spec that bootstraps the Kong gateway config, so it rotted silently — by the time #115 regenerated it, it had drifted back to the **pre-v1 API: 84 paths, zero `/v1`**. It then went stale twice more in a single day (#113's route removals, #124's new route), each caught only because I happened to be looking.

Nothing was ever going to catch it: `test_api_smoke`, `test_routes_registered` and the Dockerfile healthcheck all hit the **live** `/docs/openapi.json`, and `routes_golden.json` covers registered routes rather than the committed artifact.

## Safe as a hard gate

Generation is deterministic and independent of the env vars it needs — byte-identical output from a different cwd with bogus paths:

```
d8c24de36d1231842b7d37b344d3a76d  -            (from /tmp, bogus paths)
d8c24de36d1231842b7d37b344d3a76d  -            (again)
d8c24de36d1231842b7d37b344d3a76d  openapi.json (committed)
```

Confirmed it actually fails on a stale spec by dropping a path and re-running the check.

## Note on what this changes for everyone

Any PR that adds or modifies a route now fails CI until `openapi.json` is regenerated and committed. That is the point, but it is a new obligation — so the README recipe is fixed in the same commit. It previously died at import time without the env vars, which is part of why regenerating was easy to skip. It now runs verbatim, with a note that the variables only satisfy import-time reads and do not affect the output.