### PR TITLE
fix(runner): 400 for a missing bundle (#119); drop orphaned mass-VM schemas (#121)

### DIFF
--- a/app/schemas/vms.py
+++ b/app/schemas/vms.py
@@ -525,106 +525,6 @@ class VmActionReply(BaseModel):
 
 
 # ---------------------------------------------------------------------------
-# Mass Delete
-# ---------------------------------------------------------------------------
-
-
-class MassDeleteVmItem(BaseModel):
-    id: str = Field(..., description="Virtual machine id", pattern=r"^[0-9]+$")
-
-    name: str = Field(
-        ...,
-        description="Virtual machine meta name",
-        pattern="^[A-Za-z0-9-]+$",  #  deny void name
-        # pattern=r"^[A-Za-z0-9-]*$",
-    )
-
-
-class MassDeleteRequest(BaseModel):
-    proxmox_node: str = Field(
-        ...,
-        # default= "px-testing",
-        description="Proxmox node name",
-        pattern=r"^[A-Za-z0-9-]*$",
-    )
-
-    as_json: bool = Field(
-        default=True, description="If true : JSON output else : raw output"
-    )
-
-    vms: List[MassDeleteVmItem] = Field(
-        ...,
-        description="List of virtual machine (vm_id + vm_name)",
-        min_length=1,
-    )
-
-    model_config = {
-        "json_schema_extra": {
-            "example": {
-                "proxmox_node": "px-testing",
-                "as_json": True,
-                "vms": [
-                    {"id": "4000", "name": "vuln-box-00"},
-                    {"id": "4001", "name": "vuln-box-01"},
-                    {"id": "4002", "name": "vuln-box-02"},
-                ],
-            }
-        }
-    }
-
-
-class MassDeleteItemReply(BaseModel):
-    action: Literal["vm_start", "vm_stop", "vm_resume", "vm_pause", "vm_stop_force"]
-    source: Literal["proxmox"]
-
-    proxmox_node: str
-    vm_id: str  # int = Field(..., ge=1)
-    # vm_new_id   : str  # int = Field(..., ge=1)
-    vm_name: str
-    vm_status: Literal["running", "stopped", "paused"]
-
-
-class MassDeleteReply(BaseModel):
-    rc: int = Field(0, description="RETURN code (0 = OK)")
-    result: list[MassDeleteItemReply]
-
-
-# ---------------------------------------------------------------------------
-# Mass Start / Stop / Resume / Pause
-# ---------------------------------------------------------------------------
-
-
-class MassActionRequest(BaseModel):
-    proxmox_node: str = Field(
-        ...,
-        # default= "px-testing",
-        description="Proxmox node name",
-        pattern=r"^[A-Za-z0-9-]*$",
-    )
-
-    as_json: bool = Field(
-        default=True, description="If true : JSON output else : raw output"
-    )
-    #
-
-    vm_ids: List[str] = Field(
-        ...,
-        description="Virtual machine id",
-        min_length=1,
-    )
-
-    model_config = {
-        "json_schema_extra": {
-            "example": {
-                "proxmox_node": "px-testing",
-                "as_json": True,
-                "vm_ids": ["4000", "4001"],
-            }
-        }
-    }
-
-
-# ---------------------------------------------------------------------------
 # Backward compatibility -- old names used by current routes
 # ---------------------------------------------------------------------------
 
@@ -661,11 +561,4 @@ Request_ProxmoxVmsVMID_StartStopPauseResume = VmActionRequest
 Reply_ProxmoxVmsVMID_StartStopPauseResumeItem = VmActionItemReply
 Reply_ProxmoxVmsVMID_StartStopPauseResume = VmActionReply
 
-# vm_ids/mass_delete.py
-vm = MassDeleteVmItem
-Request_ProxmoxVmsVmIds_MassDelete = MassDeleteRequest
-Reply_ProxmoxVmsVMID_MasseDeleteItem = MassDeleteItemReply
-Reply_ProxmoxVmsVmIds_MassDelete = MassDeleteReply
 
-# vm_ids/mass_start_stop_resume_pause.py
-Request_ProxmoxVmsVmIds_MassStartStopPauseResume = MassActionRequest

--- a/app/utils/checks_playbooks.py
+++ b/app/utils/checks_playbooks.py
@@ -225,10 +225,17 @@ def _resolve_file(
     #
 
     # if not is_init_yaml:
-    if is_init_yaml is False:
-        main_filepath = (actions_dir / action_name / "main.yml").resolve(strict=True)
-    else:
-        main_filepath = (actions_dir / action_name / "init.yml").resolve(strict=True)
+    filename = "init.yml" if is_init_yaml else "main.yml"
+    try:
+        # strict=True keeps the symlink semantics the traversal check below
+        # relies on, but it raises before the "not found" branch further down
+        # could ever run — so a typo'd bundle surfaced as an unhandled
+        # FileNotFoundError, i.e. a 500 from an endpoint documented as 400.
+        main_filepath = (actions_dir / action_name / filename).resolve(strict=True)
+    except FileNotFoundError as e:
+        err = f":: err - PLAYBOOK NOT FOUND : {action_name}/{filename}"
+        logger.error(err)
+        raise HTTPException(status_code=400, detail=err) from e
 
     #
     # checks - attempt to avoid file - path traversal injections + symlinks injections

--- a/tests/test_checks_playbooks.py
+++ b/tests/test_checks_playbooks.py
@@ -65,13 +65,17 @@ class TestResolvePlaybooks:
         """Dotted <subject>.<verb>.<object> names pass format validation
         (range42-playbooks#133) and fail only on the missing file.
 
-        Asserting FileNotFoundError specifically is what makes this test
-        meaningful: the old regex rejected dots with HTTPException(400), so
-        a `raises((HTTPException, FileNotFoundError))` would pass either way.
+        Both failures are now HTTPException(400), so the assertion has to be
+        on the *detail*: NOT FOUND means the name was accepted and only the
+        file was missing, where the old regex would have said INVALID FORMAT.
+        Without that distinction this test passes either way.
         """
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(HTTPException) as exc_info:
             resolve_bundles_playbook(
                 "generic/systems.baseline.docker_host", "www_app")
+        assert exc_info.value.status_code == 400
+        assert "PLAYBOOK NOT FOUND" in exc_info.value.detail
+        assert "INVALID ACTION NAME" not in exc_info.value.detail
 
     def test_rejects_dot_segment(self):
         with pytest.raises(HTTPException) as exc_info:

--- a/tests/test_route_runner.py
+++ b/tests/test_route_runner.py
@@ -73,3 +73,18 @@ class TestRunBundle:
         """
         resp = client.post(f"/v0/admin/run/bundles/{name}/run", json=BODY)
         assert resp.status_code == 400
+
+
+class TestMissingBundle:
+    """A typo'd bundle name is a user error, not a server fault (#119)."""
+
+    def test_missing_bundle_is_400_not_500(self, client):
+        resp = client.post(
+            "/v0/admin/run/bundles/generic/does.not.exist/run", json=BODY)
+        assert resp.status_code == 400, resp.text
+        assert "PLAYBOOK NOT FOUND" in str(resp.json())
+
+    def test_missing_scenario_is_400_not_500(self, client):
+        resp = client.post(
+            "/v0/admin/run/scenarios/no_such_scenario/run", json=BODY)
+        assert resp.status_code == 400, resp.text

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -87,23 +87,6 @@ def test_vm_clone_request():
     assert req.vm_description == "cloned-vm"  # default
 
 
-def test_mass_delete_request():
-    from app.schemas.vms import MassDeleteRequest, MassDeleteVmItem
-
-    req = MassDeleteRequest(
-        proxmox_node="px-testing",
-        vms=[MassDeleteVmItem(id="4000", name="vuln-box-00")],
-    )
-    assert len(req.vms) == 1
-
-
-def test_mass_delete_request_rejects_empty_vms():
-    from app.schemas.vms import MassDeleteRequest
-
-    with pytest.raises(ValidationError):
-        MassDeleteRequest(proxmox_node="px-testing", vms=[])
-
-
 # ===========================================================================
 # vm_config.py
 # ===========================================================================
@@ -312,10 +295,6 @@ def test_backward_compat_aliases_vms():
     )
 
     assert Request_ProxmoxVmsVMID_StartStopPauseResume is VmActionRequest
-
-    from app.schemas.vms import MassDeleteRequest, Request_ProxmoxVmsVmIds_MassDelete
-
-    assert Request_ProxmoxVmsVmIds_MassDelete is MassDeleteRequest
 
 
 def test_backward_compat_aliases_vm_config():


### PR DESCRIPTION
Closes #119 and #121.

## #119 — a typo'd bundle name returned 500

`_resolve_file` calls `.resolve(strict=True)`, which raises `FileNotFoundError` **before** the `if not main_filepath.exists()` branch further down could run — so that 400 was dead code, and the docstring's `:raises HTTPException: 400 ... or the file does not exist` was a lie:

```
POST /v0/admin/run/bundles/nonexistent/run  ->  500
```

Pre-existing, but #113 sharpened it: with the hardcoded `/core/*` routes gone, every bundle invocation goes through the arbitrary-name lookup, where a typo is the normal failure — and a 500 gives the caller no way to tell "you named something that doesn't exist" from "the server broke".

Caught and translated to the 400 the code below was already written for. `strict=True` is kept deliberately: the traversal check downstream relies on its symlink resolution, so loosening it would change a security-relevant behaviour to fix a status code.

**Note on the test:** `test_accepts_dotted_segment_format` asserted `FileNotFoundError` *specifically* — that was what made it non-vacuous, since the old regex rejected dots with a 400. Both failures are 400 now, so it asserts on the detail instead: `PLAYBOOK NOT FOUND` means the name was accepted and only the file was missing, where the old regex would have said `INVALID ACTION NAME`. Without that distinction the test would pass either way again.

## #121 — dead schemas from the vm_ids removal

`MassDelete*` / `MassAction*` and their `Request_`/`Reply_` aliases were orphaned when #113 deleted the six `vm_ids/*` routes. Only tests referenced them, so those go too — along with the stray module-level `vm = MassDeleteVmItem` binding.

~100 lines of schema, 21 lines of test, no API surface change (the routes were already gone).

488 passed, ruff clean, `openapi.json` regenerated — and the new drift guard from #134 now enforces that automatically.